### PR TITLE
[deprecated / reference] Blobatars by URL (apps/service) + blobatar-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .cache
 *.tsbuildinfo
 
+# wrangler local state (apps/service)
+.wrangler
+
 # IntelliJ based IDEs
 .idea
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -131,8 +131,9 @@ consumer and is not gated at all. A blobatar can be sad and still breathing.
 ### The repo
 
 **Package**:
-A workspace member under `packages/` — publishable. Currently just
-`blobatar` itself.
+A workspace member under `packages/` — publishable. `render-core` is the
+deliberate exception: a private support package, never published, bundled into
+the surfaces that consume it.
 
 **App**:
 A workspace member under `apps/` — never published, and always consumes

--- a/apps/service/README.md
+++ b/apps/service/README.md
@@ -1,0 +1,110 @@
+# blobatar service
+
+Blobatars by URL. Paste an `<img>` tag and somebody has a face — no install,
+no JS toolchain, no build step:
+
+```html
+<img src="https://<host>/v1/alain.svg" width="48" alt="alain" />
+<img src="https://<host>/v1/alain.png?size=128&expression=happy" alt="alain" />
+```
+
+A Cloudflare Worker (`apps/service`) serving the library over HTTP. Same
+determinism contract: the same name always answers with the same bytes, which
+is what lets every response be cached immutably at the edge — after the first
+request for a name+params combination, rendering never runs again.
+
+## Routes
+
+```
+GET /v1/:name.svg
+GET /v1/:name.png
+```
+
+`:name` is one URL-encoded path segment — up to 256 characters, decoded.
+`HEAD` works everywhere `GET` does. Everything else is a 404 with a usage
+hint, or a 405.
+
+## Params
+
+| Param | Values | Default | Notes |
+|---|---|---|---|
+| `size` | integer `16`–`1024` | PNG: `256` · SVG: none | On SVG it only emits `width`/`height` attributes — omit it and CSS sizes the image (the library's own design). On PNG it is the raster width in pixels. |
+| `background` | `squircle` · `circle` · `square` · `none` | `none` | `none` is transparent — the library's own default. |
+| `hue` | integer `0`–`360` | — | Locks the hue in degrees; the name keeps driving everything else. |
+| `tone` | integer `0`–`100` | — | Locks the tone as a position in the swatch set (the library's 0–1, in URL-friendly integers). |
+| `expression` | `happy` · `sad` · `mad` · `idle` | `idle` | A static pose. `idle` is byte-identical to omitting the param. |
+| `normalize` | `true` · `false` | `true` | See [Names, ids and privacy](#names-ids-and-privacy). |
+
+Invalid values of known params are a plain-text `400`, before any rendering.
+Unknown params are ignored — pasted URLs that accumulate `utm_*` junk keep
+working and never fragment the cache.
+
+The `key` param is **reserved for future use**. Today it is ignored like any
+other unknown param; don't use it for your own purposes.
+
+### What is deliberately not a param
+
+- **`palette`** — overridden colors bypass the library's verified-contrast
+  guarantee, and the service must not serve what the library does not
+  guarantee. Lock `hue` and `tone` instead.
+- **`traits`** — an unbounded trait surface cannot be frozen contract.
+  Account-level trait pinning is future work, not a query param.
+- **`animate`** — animated blobatars are inline SVG whose idle motion gates on
+  the host page's hover; inside a remote `<img>` that channel does not exist.
+- **`title`** — accessibility text belongs to your `<img alt>`, not inside the
+  served SVG; arbitrary query text is also an injection and cache-pollution
+  surface.
+
+## Names, ids and privacy
+
+Prefer stable ids over personal data. If the natural name is an email, hash it
+client-side — `sha256(email)` is still deterministic, so it is still the same
+face everywhere (a different face than the raw email would give, but stable):
+raw emails in URLs end up in logs, caches and browser history. This is the
+same trade-off Gravatar settled with hashes.
+
+Names are normalized like the library normalizes them — NFC, trimmed,
+lowercased — so `Alain` and `alain` are one blobatar. If your names are
+case-sensitive ids (nanoid, base64), pass `normalize=false` or distinct ids
+will silently collide into one face.
+
+The served SVG carries no `<title>`: the accessible name of the image is your
+`<img alt>`.
+
+## Caching and `/v1`
+
+Responses are `Cache-Control: public, max-age=31536000, immutable`. Every
+response is cached under a canonical key — param order, default-equivalent
+params, name casing and the serving hostname never duplicate entries.
+
+`/v1/` is the library's determinism contract translated to URLs: it pins the
+current visual contract (the 0.1 line). Any visually-breaking library release
+— whatever its semver — mounts a new `/vN` while `/v1` keeps serving what it
+always served. A blobatar embedded anywhere never changes face retroactively.
+The deployed Worker pins an exact library version; bumping it within a visual
+contract is safe by the library's structural-stability guarantee.
+
+## Development
+
+```sh
+cd apps/service
+bun run dev     # builds the library, then wrangler dev
+```
+
+wrangler needs **Node ≥ 22** on the machine, even when launched through bun.
+The library must be built first because wrangler bundles workspace deps
+through their real `exports` maps, and blobatar's points at `dist/` — `bun run
+dev` does both. No Cloudflare account is needed locally.
+
+Tests are `bun test` — the whole service is a pure handler with injected
+capabilities (cache, `waitUntil`, render, rasterize), so every branch runs
+without workerd. The Cloudflare entry (`src/entry.ts`) is deliberately
+branch-free wiring, covered by running `wrangler dev`. Param-table
+correctness is `render-core`'s suite; rendering correctness is the library's.
+Programmatic Miniflare v4 does run under `bun test` (de-facto support, not
+documented by Cloudflare) and is the recorded future option if real-workerd
+integration tests ever earn their place.
+
+Deploys go to the project's Cloudflare account (`bun run deploy`, maintainer
+only). The Worker is hostname-agnostic — the public hostname is a deploy-time
+routing choice, never code.

--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "service",
+  "private": true,
+  "type": "module",
+  "//dev": "The library must be built before wrangler runs: wrangler bundles workspace deps through their exports maps, and blobatar's points at dist/. wrangler itself requires Node >= 22 on the machine, even when launched through bun.",
+  "scripts": {
+    "dev": "bun run --cwd ../../packages/blobatar build && wrangler dev",
+    "deploy": "bun run --cwd ../../packages/blobatar build && wrangler deploy",
+    "test": "bun test",
+    "check": "bun test"
+  },
+  "dependencies": {
+    "@resvg/resvg-wasm": "^2.6.2",
+    "blobatar": "workspace:*",
+    "render-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "wrangler": "^4"
+  }
+}

--- a/apps/service/src/entry.ts
+++ b/apps/service/src/entry.ts
@@ -1,0 +1,34 @@
+/**
+ * The Cloudflare entry: wires the real runtime into the pure handler and
+ * decides nothing. Every branch lives in `handler.ts`, where `bun test`
+ * reaches it; this file is covered by running `wrangler dev`.
+ */
+import { initWasm, Resvg } from "@resvg/resvg-wasm";
+import resvgWasm from "@resvg/resvg-wasm/index_bg.wasm";
+import { blobatar } from "blobatar";
+
+import { handleRequest, type WorkerCache } from "./handler";
+
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+/** One wasm init per isolate, shared by every request it serves. */
+let wasmReady: Promise<void> | undefined;
+
+export default {
+  fetch(request: Request, _env: unknown, ctx: ExecutionContext): Promise<Response> {
+    wasmReady ??= initWasm(resvgWasm);
+    return handleRequest(request, {
+      // workerd's caches carries `.default`; the DOM lib type does not know it.
+      cache: (caches as unknown as { default: WorkerCache }).default,
+      waitUntil: (promise) => ctx.waitUntil(promise),
+      render: blobatar,
+      rasterize: async (svg, size) => {
+        await wasmReady;
+        const png = new Resvg(svg, { fitTo: { mode: "width", value: size } }).render().asPng();
+        return png as Uint8Array<ArrayBuffer>;
+      },
+    });
+  },
+};

--- a/apps/service/src/handler.ts
+++ b/apps/service/src/handler.ts
@@ -1,0 +1,158 @@
+/**
+ * The whole service, as one pure function: every branch lives here, behind
+ * injected capabilities, so `bun test` covers it without workerd. The entry
+ * (`entry.ts`) wires the real runtime and holds no logic of its own.
+ */
+import type { BlobatarOptions } from "blobatar";
+import { normalizeSeed } from "blobatar";
+import {
+  PARAM_NAMES,
+  PNG_DEFAULT_SIZE,
+  parseParams,
+  type ParamName,
+  type RawParams,
+} from "render-core";
+
+export interface WorkerCache {
+  match(key: string): Promise<Response | undefined>;
+  put(key: string, response: Response): Promise<void>;
+}
+
+export interface HandlerDeps {
+  cache: WorkerCache;
+  /** Runs a promise past the response's lifetime — `ctx.waitUntil` in workerd. */
+  waitUntil(promise: Promise<unknown>): void;
+  /** `blobatar()` — the service treats its output as opaque bytes. */
+  render(name: string, options: BlobatarOptions): string;
+  /** SVG markup to PNG bytes at a pixel width. */
+  rasterize(svg: string, size: number): Promise<Uint8Array<ArrayBuffer>>;
+}
+
+/**
+ * A single URL-encoded path segment, then the format. The router matches on
+ * path only — the hostname never participates, so the Worker can be mounted
+ * anywhere.
+ */
+const ROUTE = /^\/v1\/([^/]+)\.(svg|png)$/;
+
+/**
+ * The canonical cache key's synthetic origin. Fixed and never the request's
+ * host: every hostname this Worker is mounted on shares one render cache, and
+ * a future identity layer can read the real hostname without fragmenting it.
+ */
+const CACHE_ORIGIN = "https://blobatar.cache";
+
+const CACHEABLE = "public, max-age=31536000, immutable";
+
+const USAGE = "blobatar: GET /v1/:name.svg or GET /v1/:name.png?size=256";
+
+/** Every non-image response: plain text, never cached. */
+function plain(status: number, body: string, headers?: Record<string, string>): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "no-store",
+      ...headers,
+    },
+  });
+}
+
+export async function handleRequest(request: Request, deps: HandlerDeps): Promise<Response> {
+  // HEAD rides the GET path untouched: the runtime strips the body.
+  if (request.method !== "GET" && request.method !== "HEAD")
+    return plain(405, "method not allowed", { Allow: "GET, HEAD" });
+
+  const url = new URL(request.url);
+  const match = ROUTE.exec(url.pathname);
+  if (!match) return plain(404, USAGE);
+
+  let name: string;
+  try {
+    name = decodeURIComponent(match[1]!);
+  } catch {
+    return plain(400, "name is not valid percent-encoding");
+  }
+  if (name.length > 256) return plain(400, "name must be at most 256 characters");
+  const format = match[2] as "svg" | "png";
+
+  // The allowlist, applied: anything else on the query string — utm noise,
+  // future params like `key` — is ignored and never reaches the cache key.
+  const raw: RawParams = {};
+  for (const param of PARAM_NAMES) {
+    const value = url.searchParams.get(param);
+    if (value !== null) raw[param] = value;
+  }
+  const parsed = parseParams(raw);
+  if (!parsed.ok) return plain(400, parsed.error);
+
+  // The name as the library will hash it — the identity the cache keys on.
+  const seed = parsed.options.normalize === false ? name : normalizeSeed(name);
+  if (seed === "") return plain(400, "name must not be empty");
+
+  const key = cacheKey(seed, format, parsed.canonical);
+  const hit = await deps.cache.match(key);
+  if (hit) return hit;
+
+  const response =
+    format === "svg"
+      ? svgResponse(deps.render(name, parsed.options))
+      : await pngResponse(deps, name, parsed.options);
+
+  deps.waitUntil(deps.cache.put(key, response.clone()));
+  return response;
+}
+
+/**
+ * The canonical key: synthetic origin, the name as the library will hash it,
+ * and only the params that change bytes — sorted, canonicalized, and stripped
+ * when byte-equivalent to their absence. `/v1/Alain.svg`, `/v1/alain.svg` and
+ * `/v1/alain.svg?normalize=true&utm_source=x` are one entry, not three.
+ */
+function cacheKey(
+  seed: string,
+  format: string,
+  canonical: Partial<Record<ParamName, string>>,
+): string {
+  const keyed = { ...canonical };
+  if (keyed.expression === "idle") delete keyed.expression;
+  if (keyed.normalize === "true") delete keyed.normalize;
+  if (keyed.background === "none") delete keyed.background;
+  if (format === "png" && keyed.size === String(PNG_DEFAULT_SIZE)) delete keyed.size;
+
+  const query = PARAM_NAMES.filter((p) => keyed[p] !== undefined)
+    .map((p) => `${p}=${keyed[p]}`)
+    .join("&");
+  return `${CACHE_ORIGIN}/v1/${encodeURIComponent(seed)}.${format}${query ? `?${query}` : ""}`;
+}
+
+function svgResponse(markup: string): Response {
+  return new Response(markup, {
+    headers: {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "Cache-Control": CACHEABLE,
+      // An SVG opened as a document must not be able to run anything. blobatar
+      // markup is hygienic; this is defense in depth for a hotlinkable host.
+      "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}
+
+async function pngResponse(
+  deps: HandlerDeps,
+  name: string,
+  options: BlobatarOptions,
+): Promise<Response> {
+  // The raster width comes from `fitTo`, so a width/height attribute in the
+  // source SVG would be dead weight: render without it.
+  const { size, ...rest } = options;
+  const bytes = await deps.rasterize(deps.render(name, rest), size ?? PNG_DEFAULT_SIZE);
+  return new Response(bytes, {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": CACHEABLE,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/apps/service/src/wasm.d.ts
+++ b/apps/service/src/wasm.d.ts
@@ -1,0 +1,9 @@
+/**
+ * What a `.wasm` import is inside workerd: a compiled module, ready for
+ * instantiation. wrangler's bundling provides it; this declaration only tells
+ * TypeScript so.
+ */
+declare module "*.wasm" {
+  const module: WebAssembly.Module;
+  export default module;
+}

--- a/apps/service/test/handler.test.ts
+++ b/apps/service/test/handler.test.ts
@@ -1,0 +1,255 @@
+/**
+ * The pure handler, hit as a consumer hits it: a Request in, a Response out.
+ * The injected fakes replicate the semantics of Cloudflare's own test-context
+ * pattern in ~20 lines; the branch-free entry that wires the real runtime is
+ * covered manually via `wrangler dev`.
+ *
+ * Param-table correctness (values, ranges, messages) is render-core's suite —
+ * here params only appear as integration: one accepted, one rejected, and the
+ * cache-key equivalences.
+ */
+import { describe, expect, test } from "bun:test";
+import type { BlobatarOptions } from "blobatar";
+
+import { handleRequest, type HandlerDeps } from "../src/handler";
+
+function fakes() {
+  const store = new Map<string, Response>();
+  const pending: Promise<unknown>[] = [];
+  const rendered: { name: string; options: BlobatarOptions }[] = [];
+  const deps: HandlerDeps = {
+    cache: {
+      match: async (key) => store.get(key)?.clone(),
+      put: async (key, response) => void store.set(key, response),
+    },
+    waitUntil: (promise) => void pending.push(promise),
+    render: (name, options) => {
+      rendered.push({ name, options });
+      return `<svg>${name}|${JSON.stringify(options)}</svg>`;
+    },
+    rasterize: async (svg, size) => new TextEncoder().encode(`png@${size}|${svg}`),
+  };
+  // Settles everything handed to waitUntil — what the runtime does after the
+  // response has already gone out.
+  const settle = () => Promise.all(pending).then(() => undefined);
+  return { deps, store, rendered, settle };
+}
+
+const request = (path: string, init?: RequestInit) =>
+  new Request(`https://service.example${path}`, init);
+
+describe("GET /v1/:name.svg", () => {
+  test("serves an immutable, hygienic SVG", async () => {
+    const { deps, rendered, settle } = fakes();
+    const res = await handleRequest(request("/v1/alain.svg"), deps);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml; charset=utf-8");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+    expect(res.headers.get("Content-Security-Policy")).toBe(
+      "default-src 'none'; style-src 'unsafe-inline'",
+    );
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await res.text()).toBe("<svg>alain|{}</svg>");
+    expect(rendered).toEqual([{ name: "alain", options: {} }]);
+    await settle();
+  });
+
+  test("size on SVG reaches the render options", async () => {
+    const { deps, rendered } = fakes();
+    await handleRequest(request("/v1/alain.svg?size=512"), deps);
+    expect(rendered).toEqual([{ name: "alain", options: { size: 512 } }]);
+  });
+});
+
+describe("GET /v1/:name.png", () => {
+  test("rasterizes at 256 by default, without size attributes on the source", async () => {
+    const { deps, rendered } = fakes();
+    const res = await handleRequest(request("/v1/alain.png"), deps);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(await res.text()).toBe("png@256|<svg>alain|{}</svg>");
+    expect(rendered).toEqual([{ name: "alain", options: {} }]);
+  });
+
+  test("honors ?size as the raster width, never as markup", async () => {
+    const { deps, rendered } = fakes();
+    const res = await handleRequest(request("/v1/alain.png?size=512"), deps);
+    expect(await res.text()).toBe("png@512|<svg>alain|{}</svg>");
+    expect(rendered).toEqual([{ name: "alain", options: {} }]);
+  });
+});
+
+describe("routing", () => {
+  test("HEAD is handled as GET — the runtime strips the body", async () => {
+    const { deps } = fakes();
+    const res = await handleRequest(request("/v1/alain.svg", { method: "HEAD" }), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml; charset=utf-8");
+  });
+
+  test("any other method is a 405 that names what is allowed", async () => {
+    const { deps, rendered } = fakes();
+    for (const method of ["POST", "PUT", "DELETE"]) {
+      const res = await handleRequest(request("/v1/alain.svg", { method }), deps);
+      expect(res.status).toBe(405);
+      expect(res.headers.get("Allow")).toBe("GET, HEAD");
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+    }
+    expect(rendered).toEqual([]);
+  });
+
+  test("any other path is a 404 with a one-line usage hint", async () => {
+    const { deps } = fakes();
+    for (const path of ["/", "/v1/alain", "/v1/alain.gif", "/v2/alain.svg", "/v1/a/b.svg"]) {
+      const res = await handleRequest(request(path), deps);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+      expect(await res.text()).toContain("/v1/:name.svg");
+    }
+  });
+});
+
+describe("bad requests", () => {
+  const bad = async (path: string) => {
+    const { deps, rendered } = fakes();
+    const res = await handleRequest(request(path), deps);
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    // 400 means *before any rendering* — cache poisoning and wasted CPU both die here.
+    expect(rendered).toEqual([]);
+    return res.text();
+  };
+
+  test("malformed percent-encoding in the name", async () => {
+    // The reference implementation 500ed here; the decode is guarded.
+    expect(await bad("/v1/%E0%A4%A.svg")).toBe("name is not valid percent-encoding");
+  });
+
+  test("name longer than 256 characters after decoding", async () => {
+    expect(await bad(`/v1/${"a".repeat(257)}.svg`)).toBe(
+      "name must be at most 256 characters",
+    );
+  });
+
+  test("name empty after normalization", async () => {
+    // A name stands for somebody; empty is a caller bug, not a face.
+    expect(await bad("/v1/%20%20.svg")).toBe("name must not be empty");
+  });
+
+  test("empty name is only reachable when normalization trims it", async () => {
+    // With normalize=false the same whitespace is a legitimate, verbatim seed.
+    const { deps, rendered } = fakes();
+    const res = await handleRequest(request("/v1/%20%20.svg?normalize=false"), deps);
+    expect(res.status).toBe(200);
+    expect(rendered).toEqual([{ name: "  ", options: { normalize: false } }]);
+  });
+
+  test("an invalid param value surfaces render-core's message verbatim", async () => {
+    expect(await bad("/v1/alain.svg?hue=999")).toBe(
+      "hue must be an integer between 0 and 360",
+    );
+  });
+});
+
+describe("caching", () => {
+  test("a second equivalent request is served from cache without rendering", async () => {
+    const { deps, rendered, settle } = fakes();
+    const first = await handleRequest(request("/v1/alain.svg"), deps);
+    await settle();
+    const second = await handleRequest(request("/v1/alain.svg"), deps);
+
+    expect(rendered).toHaveLength(1);
+    expect(await second.text()).toBe(await first.text());
+    expect(second.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+  });
+
+  test("the cache write rides waitUntil, never the response", async () => {
+    const { deps, store, settle } = fakes();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const put = deps.cache.put;
+    deps.cache.put = async (key, response) => {
+      await gate;
+      return put(key, response);
+    };
+
+    const res = await handleRequest(request("/v1/alain.svg"), deps);
+    expect(res.status).toBe(200);
+    expect(store.size).toBe(0);
+
+    release();
+    await settle();
+    expect(store.size).toBe(1);
+  });
+});
+
+describe("canonical cache key", () => {
+  /** The single key a request stores under. */
+  const keyOf = async (path: string, host = "https://service.example") => {
+    const { deps, store, settle } = fakes();
+    await handleRequest(new Request(`${host}${path}`), deps);
+    await settle();
+    expect(store.size).toBe(1);
+    return [...store.keys()][0]!;
+  };
+
+  test("param order does not fragment the cache", async () => {
+    expect(await keyOf("/v1/alain.svg?tone=40&hue=210")).toBe(
+      await keyOf("/v1/alain.svg?hue=210&tone=40"),
+    );
+  });
+
+  test("params byte-equivalent to their absence are stripped", async () => {
+    const bare = await keyOf("/v1/alain.svg");
+    expect(await keyOf("/v1/alain.svg?expression=idle")).toBe(bare);
+    expect(await keyOf("/v1/alain.svg?normalize=true")).toBe(bare);
+    expect(await keyOf("/v1/alain.svg?background=none")).toBe(bare);
+    // size=256 is a default on PNG only; on SVG it emits attributes.
+    expect(await keyOf("/v1/alain.png?size=256")).toBe(await keyOf("/v1/alain.png"));
+    expect(await keyOf("/v1/alain.svg?size=256")).not.toBe(bare);
+  });
+
+  test("params that change bytes each get their own entry", async () => {
+    const bare = await keyOf("/v1/alain.svg");
+    expect(await keyOf("/v1/alain.svg?expression=happy")).not.toBe(bare);
+    expect(await keyOf("/v1/alain.svg?hue=210")).not.toBe(bare);
+    expect(await keyOf("/v1/alain.png")).not.toBe(bare);
+  });
+
+  test("unknown params are ignored, never keyed", async () => {
+    expect(await keyOf("/v1/alain.svg?utm_source=x&fbclid=y&key=abc")).toBe(
+      await keyOf("/v1/alain.svg"),
+    );
+  });
+
+  test("the name is keyed as the library will hash it", async () => {
+    expect(await keyOf("/v1/Alain.svg")).toBe(await keyOf("/v1/alain.svg"));
+    expect(await keyOf("/v1/%20alain%20.svg")).toBe(await keyOf("/v1/alain.svg"));
+    // normalize=false keys the verbatim name — distinct ids stay distinct.
+    expect(await keyOf("/v1/Alain.svg?normalize=false")).not.toBe(
+      await keyOf("/v1/alain.svg?normalize=false"),
+    );
+  });
+
+  test("the key never carries the request's host", async () => {
+    const a = await keyOf("/v1/alain.svg", "https://avatars.blobatar.dev");
+    const b = await keyOf("/v1/alain.svg", "https://acme.blobatar.dev");
+    expect(a).toBe(b);
+    expect(a).not.toContain("blobatar.dev");
+  });
+
+  test("two hosts share one live cache entry", async () => {
+    const { deps, rendered, settle } = fakes();
+    await handleRequest(new Request("https://a.example/v1/alain.svg"), deps);
+    await settle();
+    await handleRequest(new Request("https://b.example/v1/alain.svg"), deps);
+    expect(rendered).toHaveLength(1);
+  });
+});

--- a/apps/service/tsconfig.json
+++ b/apps/service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // No react here — the root default lists it and this member never renders JSX.
+    "types": ["bun"]
+  },
+  "include": ["src", "test"]
+}

--- a/apps/service/wrangler.toml
+++ b/apps/service/wrangler.toml
@@ -1,0 +1,10 @@
+# Deploys to Alain's Cloudflare account. Contributors only ever run
+# `bun run dev` — wrangler serves the Worker locally and needs no account.
+name = "blobatar-service"
+main = "src/entry.ts"
+compatibility_date = "2026-08-01"
+
+# No routes on purpose: the Worker is hostname-agnostic by design, so the
+# public hostname is a deploy-time choice that never touches code. The .wasm
+# import rides wrangler's default bundling rules; if bundling is ever
+# customized, add an explicit CompiledWasm rule for "**/*.wasm".

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,21 @@
         "react",
       ],
     },
+    "packages/cli": {
+      "name": "blobatar-cli",
+      "version": "0.1.0",
+      "bin": {
+        "blobatar": "./dist/blobatar.mjs",
+      },
+      "dependencies": {
+        "@resvg/resvg-js": "^2.6.2",
+        "blobatar": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "render-core": "workspace:*",
+      },
+    },
     "packages/render-core": {
       "name": "render-core",
       "dependencies": {
@@ -461,6 +476,32 @@
 
     "@remotion/zod-types": ["@remotion/zod-types@4.0.512", "", { "dependencies": { "remotion": "4.0.512" } }, "sha512-A6vOKALJf/p3ldTJUfsWxEine3gi6WHg4w7Vb2IXyVc5QW51CFBN8Zkdo9U/4cPCTSAaai+z3s+glIcQwfHw7g=="],
 
+    "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
+
+    "@resvg/resvg-js-android-arm-eabi": ["@resvg/resvg-js-android-arm-eabi@2.6.2", "", { "os": "android", "cpu": "arm" }, "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA=="],
+
+    "@resvg/resvg-js-android-arm64": ["@resvg/resvg-js-android-arm64@2.6.2", "", { "os": "android", "cpu": "arm64" }, "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ=="],
+
+    "@resvg/resvg-js-darwin-arm64": ["@resvg/resvg-js-darwin-arm64@2.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A=="],
+
+    "@resvg/resvg-js-darwin-x64": ["@resvg/resvg-js-darwin-x64@2.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw=="],
+
+    "@resvg/resvg-js-linux-arm-gnueabihf": ["@resvg/resvg-js-linux-arm-gnueabihf@2.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw=="],
+
+    "@resvg/resvg-js-linux-arm64-gnu": ["@resvg/resvg-js-linux-arm64-gnu@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg=="],
+
+    "@resvg/resvg-js-linux-arm64-musl": ["@resvg/resvg-js-linux-arm64-musl@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg=="],
+
+    "@resvg/resvg-js-linux-x64-gnu": ["@resvg/resvg-js-linux-x64-gnu@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw=="],
+
+    "@resvg/resvg-js-linux-x64-musl": ["@resvg/resvg-js-linux-x64-musl@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ=="],
+
+    "@resvg/resvg-js-win32-arm64-msvc": ["@resvg/resvg-js-win32-arm64-msvc@2.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ=="],
+
+    "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
+
+    "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
+
     "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
 
     "@rspack/binding": ["@rspack/binding@1.7.11", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.7.11", "@rspack/binding-darwin-x64": "1.7.11", "@rspack/binding-linux-arm64-gnu": "1.7.11", "@rspack/binding-linux-arm64-musl": "1.7.11", "@rspack/binding-linux-x64-gnu": "1.7.11", "@rspack/binding-linux-x64-musl": "1.7.11", "@rspack/binding-wasm32-wasi": "1.7.11", "@rspack/binding-win32-arm64-msvc": "1.7.11", "@rspack/binding-win32-ia32-msvc": "1.7.11", "@rspack/binding-win32-x64-msvc": "1.7.11" } }, "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q=="],
@@ -638,6 +679,8 @@
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "blobatar": ["blobatar@workspace:packages/blobatar"],
+
+    "blobatar-cli": ["blobatar-cli@workspace:packages/cli"],
 
     "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,15 @@
         "react",
       ],
     },
+    "packages/render-core": {
+      "name": "render-core",
+      "dependencies": {
+        "blobatar": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -847,6 +856,8 @@
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "remotion": ["remotion@4.0.512", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-L47ImosLFn/uSEGhgV6nO9agEjrRTD+xfeIC4QlGSkCkHjG4IpH2dm0psRoLrK0eo8iiUc4rwUFNnNxQpLnx2w=="],
+
+    "render-core": ["render-core@workspace:packages/render-core"],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,18 @@
         "@types/react-dom": "^19",
       },
     },
+    "apps/service": {
+      "name": "service",
+      "dependencies": {
+        "@resvg/resvg-wasm": "^2.6.2",
+        "blobatar": "workspace:*",
+        "render-core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "wrangler": "^4",
+      },
+    },
     "apps/site": {
       "name": "site",
       "dependencies": {
@@ -449,6 +461,8 @@
 
     "@remotion/zod-types": ["@remotion/zod-types@4.0.512", "", { "dependencies": { "remotion": "4.0.512" } }, "sha512-A6vOKALJf/p3ldTJUfsWxEine3gi6WHg4w7Vb2IXyVc5QW51CFBN8Zkdo9U/4cPCTSAaai+z3s+glIcQwfHw7g=="],
 
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
+
     "@rspack/binding": ["@rspack/binding@1.7.11", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.7.11", "@rspack/binding-darwin-x64": "1.7.11", "@rspack/binding-linux-arm64-gnu": "1.7.11", "@rspack/binding-linux-arm64-musl": "1.7.11", "@rspack/binding-linux-x64-gnu": "1.7.11", "@rspack/binding-linux-x64-musl": "1.7.11", "@rspack/binding-wasm32-wasi": "1.7.11", "@rspack/binding-win32-arm64-msvc": "1.7.11", "@rspack/binding-win32-ia32-msvc": "1.7.11", "@rspack/binding-win32-x64-msvc": "1.7.11" } }, "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q=="],
 
     "@rspack/binding-darwin-arm64": ["@rspack/binding-darwin-arm64@1.7.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig=="],
@@ -868,6 +882,8 @@
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
     "semver": ["semver@7.5.3", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="],
+
+    "service": ["service@workspace:apps/service"],
 
     "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,84 @@
+# blobatar-cli
+
+Deterministic geometric blobatars from any string, in your terminal. No JS
+project required — designers, CI pipelines, shell scripts, database seeds:
+
+```sh
+npx blobatar-cli alain > alain.svg     # or: bunx blobatar-cli alain
+```
+
+Install it globally and the command is just `blobatar`:
+
+```sh
+npm i -g blobatar-cli                  # or: bun add -g blobatar-cli
+blobatar alain
+```
+
+## Usage
+
+```
+blobatar <name>                          SVG to stdout
+blobatar <name> -o alain.svg             to a file; format from the extension
+blobatar <name> -o alain.png --size 512
+blobatar <name> --background circle --hue 210 --tone 40 --expression happy
+blobatar --stdin -d ./blobatars/         batch: one name per line on stdin
+```
+
+The flags mirror the blobatar service's `/v1` URL params exactly — same names,
+same values, same validation, same error messages — so knowledge transfers
+between the two in both directions:
+
+| Flag | Values | Default | Notes |
+|---|---|---|---|
+| `--size` | integer `16`–`1024` | PNG: `256` · SVG: none | On SVG it only emits `width`/`height` attributes. On PNG it is the raster width in pixels. |
+| `--background` | `squircle` · `circle` · `square` · `none` | `none` | `none` is transparent — the library's own default. |
+| `--hue` | integer `0`–`360` | — | Locks the hue in degrees; the name keeps driving everything else. |
+| `--tone` | integer `0`–`100` | — | Locks the tone as a position in the swatch set. |
+| `--expression` | `happy` · `sad` · `mad` · `idle` | `idle` | A static pose. |
+| `--no-normalize` | — | — | Keeps the name's case and spacing. Names are otherwise normalized (NFC, trimmed, lowercased) so `Alain` and `alain` are one blobatar; for case-sensitive ids that normalization silently collides distinct ids — this flag is the fix. |
+
+## Output rules
+
+SVG goes to stdout by default, so the tool composes with pipes and redirects.
+PNG is binary and never lands on a TTY: write it with `-o file.png`, or pipe
+stdout together with `--format png`. With `-o` the extension decides the
+format, and a contradicting `--format` is an error. Errors go to stderr —
+stdout carries only image bytes — and the exit code is `0` on success, `1` on
+any failure.
+
+## Batch
+
+```sh
+cut -d, -f1 users.csv | blobatar --stdin -d ./blobatars/ --format png
+```
+
+One name per line, trimmed, empty lines skipped. Each file is named by a
+deterministic sanitization of the name — the same normalization the render
+applies, then anything outside `[A-Za-z0-9._-]` becomes `_`, capped at 200
+characters. Every filename is computed before anything is written: if two
+names map to the same file, the whole batch aborts with an error listing them,
+and nothing is partially written. An exact duplicate line is the same
+blobatar twice, so it is simply deduped, not a collision.
+
+## Determinism, in CI
+
+Same input, same bytes: SVG output is byte-identical for the same name and
+flags within a visual-contract major of the library (this package's major
+tracks it). PNG is visually identical, but its bytes are tied to the resvg
+version in your lockfile — an honest split worth knowing before you diff.
+
+The pattern that follows: generate your team's blobatars in the build, commit
+them, and diffs stay clean until a visual major.
+
+```sh
+blobatar --stdin -d assets/blobatars/ < team.txt
+git diff --exit-code assets/blobatars/   # fails the build if a face changed
+```
+
+## Runtime
+
+Node ≥ 18 or bun. The published package is plain JS with exactly two runtime
+dependencies: `blobatar` (the renderer) and `@resvg/resvg-js` (PNG via native
+prebuilds — per-platform `optionalDependencies`, no postinstall scripts). The
+CLI never talks to the network, and the blobatar service never runs this code:
+they are parallel consumers of the same library.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "blobatar-cli",
+  "version": "0.1.0",
+  "description": "Deterministic geometric blobatars from any string, in your terminal.",
+  "type": "module",
+  "bin": { "blobatar": "./dist/blobatar.mjs" },
+  "files": ["dist", "README.md"],
+  "//engines": "The published artifact runs under plain node — npx is where the non-JS-project audience lives — so src/ uses no Bun-only APIs. A deliberate, documented exception to the repo's Bun-first preference; bun and bunx work too.",
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "test": "bun test",
+    "build": "bun scripts/build.ts",
+    "smoke": "node scripts/smoke.mjs",
+    "check": "bun test && bun run build && bun run smoke",
+    "prepack": "bun run build"
+  },
+  "//dependencies": "Exactly these two at runtime: render-core is private and gets inlined into dist by the build. resvg-js ships per-platform napi prebuilds as optionalDependencies with no postinstall.",
+  "dependencies": {
+    "@resvg/resvg-js": "^2.6.2",
+    "blobatar": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "render-core": "workspace:*"
+  },
+  "keywords": ["blobatar", "avatar", "identicon", "svg", "png", "cli", "deterministic"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues"
+}

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -1,0 +1,26 @@
+/**
+ * Builds the published bin: one plain-JS ESM file with the private
+ * `render-core` inlined (it is never published, so it cannot stay an import)
+ * and the two real runtime dependencies — `blobatar` and `@resvg/resvg-js` —
+ * left external, to be resolved from the consumer's node_modules.
+ */
+import { chmod } from "node:fs/promises";
+
+const result = await Bun.build({
+  entrypoints: ["src/main.ts"],
+  outdir: "dist",
+  target: "node",
+  format: "esm",
+  naming: "blobatar.mjs",
+  external: ["blobatar", "blobatar/*", "@resvg/resvg-js"],
+  banner: "#!/usr/bin/env node",
+});
+
+if (!result.success) {
+  for (const log of result.logs) console.error(log);
+  process.exit(1);
+}
+
+await chmod("dist/blobatar.mjs", 0o755);
+const built = result.outputs[0];
+console.log(`✓ dist/blobatar.mjs (${built ? built.size : "?"} bytes)`);

--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -1,0 +1,73 @@
+/**
+ * What a consumer gets, checked the way a consumer gets it: the built bin,
+ * spawned under Node — the runtime npx uses — with the real library and the
+ * real resvg prebuild. Prior art: the library package's own smoke.mjs.
+ *
+ * Plain .mjs on purpose: nothing may transpile it.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const bin = fileURLToPath(new URL("../dist/blobatar.mjs", import.meta.url));
+const dir = mkdtempSync(join(tmpdir(), "blobatar-cli-"));
+
+let failed = false;
+const check = (name, fn) => {
+  try {
+    const detail = fn();
+    console.log(`✓ ${name}${detail ? ` — ${detail}` : ""}`);
+  } catch (err) {
+    console.error(`✗ ${name} — ${err.message}`);
+    failed = true;
+  }
+};
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg);
+};
+const cli = (args, input) =>
+  spawnSync(process.execPath, [bin, ...args], {
+    input: input === undefined ? undefined : Buffer.from(input),
+  });
+
+check("svg to stdout", () => {
+  const r = cli(["alain"]);
+  assert(r.status === 0, `exit ${r.status}: ${r.stderr}`);
+  const svg = r.stdout.toString("utf8");
+  assert(svg.startsWith("<svg"), `did not print SVG: ${svg.slice(0, 40)}`);
+  return `${svg.length} chars`;
+});
+
+check("determinism", () => {
+  assert(cli(["alain"]).stdout.equals(cli(["alain"]).stdout), "same name, different bytes");
+  return "same in, same out";
+});
+
+check("png via -o (real resvg prebuild)", () => {
+  const file = join(dir, "alain.png");
+  const r = cli(["alain", "-o", file, "--size", "64"]);
+  assert(r.status === 0, `exit ${r.status}: ${r.stderr}`);
+  const bytes = readFileSync(file);
+  assert(bytes[0] === 0x89 && bytes[1] === 0x50, "file has no PNG magic");
+  return `${bytes.length} bytes`;
+});
+
+check("batch from stdin", () => {
+  const out = join(dir, "batch");
+  const r = cli(["--stdin", "-d", out], "alain\nsofia\n");
+  assert(r.status === 0, `exit ${r.status}: ${r.stderr}`);
+  const files = readdirSync(out).sort().join(",");
+  assert(files === "alain.svg,sofia.svg", `wrote ${files}`);
+  return files;
+});
+
+check("errors exit 1, stderr only", () => {
+  const r = cli(["alain", "--hue", "999"]);
+  assert(r.status === 1, `exit ${r.status}`);
+  assert(r.stdout.length === 0, "stdout was not empty");
+  assert(String(r.stderr).includes("hue must be an integer"), `stderr: ${r.stderr}`);
+});
+
+process.exit(failed ? 1 : 0);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -149,12 +149,14 @@ export async function run(io: CliIO, deps: CliDeps): Promise<0 | 1> {
   if (parsed.stdin) {
     const dir = parsed.dir!.replace(/\/+$/, "");
     const format = parsed.format ?? "svg";
-    const names: string[] = [];
+    // An exact duplicate is the same blobatar twice — deduped, not an error.
+    // A Set keeps insertion order, so output order still follows the input.
+    const seen = new Set<string>();
     for (const line of (await io.readStdin()).split("\n")) {
       const name = line.trim();
-      // An exact duplicate is the same blobatar twice — deduped, not an error.
-      if (name !== "" && !names.includes(name)) names.push(name);
+      if (name !== "") seen.add(name);
     }
+    const names = [...seen];
     if (names.length === 0) return fail("stdin carried no names");
 
     // Every filename is precomputed before anything touches disk: a collision

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,228 @@
+/**
+ * The whole CLI, as one pure function: every branch lives here, behind an
+ * injected process seam, so `bun test` covers the flag/output/batch matrix
+ * in-process. `main.ts` wires the real process and decides nothing.
+ *
+ * Runs under plain Node (>= 18) by design — no Bun-only APIs in this file —
+ * because the published artifact's audience is npx. A deliberate, documented
+ * exception to the repo's Bun-first preference.
+ */
+import type { BlobatarOptions } from "blobatar";
+import { normalizeSeed } from "blobatar";
+import { PNG_DEFAULT_SIZE, parseParams, type ParamName, type RawParams } from "render-core";
+
+export interface CliIO {
+  /** argv after the runtime and script entries. */
+  argv: string[];
+  readStdin(): Promise<string>;
+  stdoutIsTTY: boolean;
+  writeStdout(data: Uint8Array | string): void;
+  writeStderr(text: string): void;
+  writeFile(path: string, data: Uint8Array | string): Promise<void>;
+  /** Recursive, like `mkdir -p`. */
+  mkdir(dir: string): Promise<void>;
+}
+
+export interface CliDeps {
+  /** `blobatar()` — the CLI treats its output as opaque bytes. */
+  render(name: string, options: BlobatarOptions): string;
+  /** SVG markup to PNG bytes at a pixel width. */
+  rasterize(svg: string, size: number): Promise<Uint8Array>;
+  /** The package version, for `--version`. */
+  version: string;
+}
+
+export const USAGE = `Usage:
+  blobatar <name>                          SVG to stdout
+  blobatar <name> -o alain.svg             to a file; format from the extension
+  blobatar <name> -o alain.png --size 512
+  blobatar --stdin -d ./blobatars/         batch: one name per line on stdin
+
+Options:
+  --size <n>          16-1024. PNG: raster width (default 256). SVG: width/height attributes
+  --background <v>    squircle | circle | square | none (default none, transparent)
+  --hue <n>           lock the hue, degrees 0-360
+  --tone <n>          lock the tone, 0-100
+  --expression <v>    happy | sad | mad | idle
+  --no-normalize      keep the name's case/spacing (for case-sensitive ids)
+  -o, --out <file>    write one blobatar to <file> (.svg or .png)
+  -d, --dir <dir>     batch only: directory for one file per name
+  --stdin             read names from stdin, one per line (requires -d)
+  --format <v>        svg | png - for stdout pipes and batch (default svg)
+  -h, --help          this text
+  --version           print the version
+`;
+
+/** Flags that carry one of the six shared params, straight into render-core. */
+const PARAM_FLAGS: Record<string, ParamName> = {
+  "--size": "size",
+  "--background": "background",
+  "--hue": "hue",
+  "--tone": "tone",
+  "--expression": "expression",
+};
+
+interface Parsed {
+  name?: string;
+  raw: RawParams;
+  out?: string;
+  dir?: string;
+  stdin: boolean;
+  format?: "svg" | "png";
+  help: boolean;
+  version: boolean;
+}
+
+/** argv to a plain description of what was asked — no validation beyond shape. */
+function parseArgv(argv: string[]): Parsed | { error: string } {
+  const parsed: Parsed = { raw: {}, stdin: false, help: false, version: false };
+  const take = (flag: string, inline: string | undefined, rest: string[]) => {
+    if (inline !== undefined) return inline;
+    const value = rest.shift();
+    return value === undefined ? { error: `${flag} requires a value` } : value;
+  };
+
+  const rest = [...argv];
+  while (rest.length > 0) {
+    const token = rest.shift()!;
+    // `--flag=value` is the same as `--flag value`.
+    const eq = token.startsWith("--") ? token.indexOf("=") : -1;
+    const flag = eq === -1 ? token : token.slice(0, eq);
+    const inline = eq === -1 ? undefined : token.slice(eq + 1);
+
+    if (flag === "-h" || flag === "--help") parsed.help = true;
+    else if (flag === "--version") parsed.version = true;
+    else if (flag === "--stdin") parsed.stdin = true;
+    else if (flag === "--no-normalize") parsed.raw.normalize = "false";
+    else if (flag in PARAM_FLAGS) {
+      const value = take(flag, inline, rest);
+      if (typeof value !== "string") return value;
+      parsed.raw[PARAM_FLAGS[flag]!] = value;
+    } else if (flag === "-o" || flag === "--out" || flag === "-d" || flag === "--dir" || flag === "--format") {
+      const value = take(flag, inline, rest);
+      if (typeof value !== "string") return value;
+      if (flag === "--format") {
+        if (value !== "svg" && value !== "png") return { error: "format must be svg or png" };
+        parsed.format = value;
+      } else if (flag === "-o" || flag === "--out") parsed.out = value;
+      else parsed.dir = value;
+    } else if (flag.startsWith("-") && flag !== "-") {
+      return { error: `unknown option ${flag} (see blobatar --help)` };
+    } else if (parsed.name !== undefined) {
+      return { error: `expected one name, got "${parsed.name}" and "${token}"` };
+    } else {
+      parsed.name = token;
+    }
+  }
+  return parsed;
+}
+
+export async function run(io: CliIO, deps: CliDeps): Promise<0 | 1> {
+  const fail = (message: string): 1 => {
+    io.writeStderr(`blobatar: ${message}\n`);
+    return 1;
+  };
+
+  const parsed = parseArgv(io.argv);
+  if ("error" in parsed) return fail(parsed.error);
+  if (parsed.help) {
+    io.writeStdout(USAGE);
+    return 0;
+  }
+  if (parsed.version) {
+    io.writeStdout(`${deps.version}\n`);
+    return 0;
+  }
+
+  const params = parseParams(parsed.raw);
+  if (!params.ok) return fail(params.error);
+  const options = params.options;
+
+  if (parsed.out !== undefined && parsed.dir !== undefined)
+    return fail("-o and -d are mutually exclusive");
+  if (parsed.stdin && parsed.name !== undefined)
+    return fail("--stdin reads names from stdin; drop the positional name");
+  if (parsed.stdin && parsed.dir === undefined) return fail("--stdin requires -d <dir>");
+  if (!parsed.stdin && parsed.dir !== undefined)
+    return fail("-d is for batches and requires --stdin (write one blobatar with -o)");
+
+  if (parsed.stdin) {
+    const dir = parsed.dir!.replace(/\/+$/, "");
+    const format = parsed.format ?? "svg";
+    const names: string[] = [];
+    for (const line of (await io.readStdin()).split("\n")) {
+      const name = line.trim();
+      // An exact duplicate is the same blobatar twice — deduped, not an error.
+      if (name !== "" && !names.includes(name)) names.push(name);
+    }
+    if (names.length === 0) return fail("stdin carried no names");
+
+    // Every filename is precomputed before anything touches disk: a collision
+    // aborts the whole batch instead of silently overwriting a blobatar.
+    const normalize = options.normalize !== false;
+    const byFile = new Map<string, string[]>();
+    for (const name of names) {
+      const file = `${filename(name, normalize)}.${format}`;
+      const owners = byFile.get(file);
+      if (owners) owners.push(name);
+      else byFile.set(file, [name]);
+    }
+    const collisions = [...byFile].filter(([, owners]) => owners.length > 1);
+    if (collisions.length > 0)
+      return fail(
+        "filename collision — nothing written:\n" +
+          collisions
+            .map(([file, owners]) => `  ${file}: ${owners.map((n) => JSON.stringify(n)).join(", ")}`)
+            .join("\n"),
+      );
+
+    await io.mkdir(dir);
+    for (const [file, [name]] of byFile) {
+      const data = format === "svg" ? deps.render(name!, options) : await png(deps, name!, options);
+      await io.writeFile(`${dir}/${file}`, data);
+    }
+    return 0;
+  }
+
+  const name = parsed.name;
+  if (name === undefined) return fail("missing name (see blobatar --help)");
+
+  let format: "svg" | "png";
+  const out = parsed.out;
+  if (out !== undefined) {
+    // The extension decides; --format may only agree.
+    const dot = out.lastIndexOf(".");
+    const ext = dot === -1 ? "" : out.slice(dot + 1);
+    if (ext !== "svg" && ext !== "png")
+      return fail(`output file must end in .svg or .png, got "${out}"`);
+    if (parsed.format !== undefined && parsed.format !== ext)
+      return fail(`--format ${parsed.format} contradicts the .${ext} extension of ${out}`);
+    format = ext;
+  } else {
+    format = parsed.format ?? "svg";
+    // stdout carries only image bytes, and binary bytes ruin a terminal.
+    if (format === "png" && io.stdoutIsTTY)
+      return fail("PNG is binary — write it with -o <file>.png, or pipe stdout");
+  }
+
+  const data = format === "svg" ? deps.render(name, options) : await png(deps, name, options);
+  if (out !== undefined) await io.writeFile(out, data);
+  else io.writeStdout(data);
+  return 0;
+}
+
+/** PNG bytes for one name: raster width from `size`, never markup attributes. */
+async function png(deps: CliDeps, name: string, options: BlobatarOptions): Promise<Uint8Array> {
+  const { size, ...rest } = options;
+  return deps.rasterize(deps.render(name, rest), size ?? PNG_DEFAULT_SIZE);
+}
+
+/**
+ * A batch output filename: the identity the render will hash — normalized
+ * exactly when the render normalizes — made filesystem-safe. Deterministic,
+ * so a re-run of the same list lands on the same files.
+ */
+function filename(name: string, normalize: boolean): string {
+  const identity = normalize ? normalizeSeed(name) : name;
+  return identity.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 200);
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,41 @@
+/**
+ * The real process, wired into the pure CLI and deciding nothing. Node APIs
+ * only — the published bin runs under npx on machines that have never met bun.
+ * The shebang is stamped by `scripts/build.ts`.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+import { Resvg } from "@resvg/resvg-js";
+import { blobatar } from "blobatar";
+
+import { version } from "../package.json";
+import { run } from "./cli";
+
+const code = await run(
+  {
+    argv: process.argv.slice(2),
+    readStdin: async () => {
+      process.stdin.setEncoding("utf8");
+      let input = "";
+      for await (const chunk of process.stdin) input += chunk;
+      return input;
+    },
+    stdoutIsTTY: Boolean(process.stdout.isTTY),
+    writeStdout: (data) => void process.stdout.write(data),
+    writeStderr: (text) => void process.stderr.write(text),
+    writeFile: (path, data) => writeFile(path, data),
+    mkdir: (dir) => mkdir(dir, { recursive: true }).then(() => undefined),
+  },
+  {
+    render: blobatar,
+    rasterize: async (svg, size) =>
+      new Resvg(svg, { fitTo: { mode: "width", value: size } }).render().asPng(),
+    version,
+  },
+);
+
+// Not process.exit(): a forced exit can truncate PNG bytes still flushing
+// through a pipe. With stdin consumed and no handles left, node exits on its
+// own carrying this code.
+process.exitCode = code;

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,0 +1,257 @@
+/**
+ * The whole flag/output/batch matrix, in-process through the injected process
+ * seam (argv, stdin, stdout-TTY-ness, file writes). One end-to-end smoke
+ * (`scripts/smoke.mjs`) spawns the built bin under node; param-table
+ * correctness (values, ranges, messages) is render-core's suite.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { run, type CliDeps, type CliIO } from "../src/cli";
+
+function cli(argv: string[], opts: { tty?: boolean; stdin?: string } = {}) {
+  const out: (Uint8Array | string)[] = [];
+  const err: string[] = [];
+  const files = new Map<string, Uint8Array | string>();
+  const dirs: string[] = [];
+  const io: CliIO = {
+    argv,
+    readStdin: async () => opts.stdin ?? "",
+    stdoutIsTTY: opts.tty ?? false,
+    writeStdout: (data) => void out.push(data),
+    writeStderr: (text) => void err.push(text),
+    writeFile: async (path, data) => void files.set(path, data),
+    mkdir: async (dir) => void dirs.push(dir),
+  };
+  const deps: CliDeps = {
+    render: (name, options) => `<svg>${name}|${JSON.stringify(options)}</svg>`,
+    rasterize: async (svg, size) => new TextEncoder().encode(`png@${size}|${svg}`),
+    version: "0.0.0-test",
+  };
+  return { out, err, files, dirs, run: () => run(io, deps) };
+}
+
+const text = (chunks: (Uint8Array | string)[]) =>
+  chunks.map((c) => (typeof c === "string" ? c : new TextDecoder().decode(c))).join("");
+
+describe("single blobatar", () => {
+  test("a name alone writes SVG to stdout", async () => {
+    const c = cli(["alain"]);
+    expect(await c.run()).toBe(0);
+    expect(text(c.out)).toBe("<svg>alain|{}</svg>");
+    expect(c.err).toEqual([]);
+    expect(c.files.size).toBe(0);
+  });
+
+  test("flags mirror /v1 into the same options", async () => {
+    const c = cli([
+      "alain",
+      "--background", "circle",
+      "--hue", "210",
+      "--tone", "40",
+      "--expression", "happy",
+      "--size", "512",
+      "--no-normalize",
+    ]);
+    expect(await c.run()).toBe(0);
+    const options = JSON.parse(text(c.out).split("|")[1]!.replace("</svg>", ""));
+    expect(options).toMatchObject({
+      background: "circle",
+      hue: 210,
+      tone: 0.4,
+      size: 512,
+      normalize: false,
+    });
+    expect(options.expression).toBeDefined();
+  });
+
+  test("--flag=value works like --flag value", async () => {
+    const c = cli(["alain", "--hue=210"]);
+    expect(await c.run()).toBe(0);
+    expect(text(c.out)).toContain('"hue":210');
+  });
+
+  test("an invalid value fails with render-core's message, stdout untouched", async () => {
+    const c = cli(["alain", "--hue", "999"]);
+    expect(await c.run()).toBe(1);
+    expect(c.out).toEqual([]);
+    expect(text(c.err as unknown as string[])).toContain(
+      "hue must be an integer between 0 and 360",
+    );
+  });
+
+  test("a value-taking flag with nothing after it fails", async () => {
+    const c = cli(["alain", "--hue"]);
+    expect(await c.run()).toBe(1);
+    expect(c.err.join("")).toContain("--hue requires a value");
+  });
+
+  test("an unknown option fails loudly", async () => {
+    const c = cli(["alain", "--palette", "red"]);
+    expect(await c.run()).toBe(1);
+    expect(c.err.join("")).toContain("unknown option --palette");
+  });
+});
+
+describe("-o", () => {
+  test("the .svg extension writes markup to the file, nothing to stdout", async () => {
+    const c = cli(["alain", "-o", "alain.svg"]);
+    expect(await c.run()).toBe(0);
+    expect(c.out).toEqual([]);
+    expect(c.files.get("alain.svg")).toBe("<svg>alain|{}</svg>");
+  });
+
+  test("the .png extension rasterizes at 256 by default, size never in markup", async () => {
+    const c = cli(["alain", "-o", "alain.png"]);
+    expect(await c.run()).toBe(0);
+    expect(text([c.files.get("alain.png")!])).toBe("png@256|<svg>alain|{}</svg>");
+  });
+
+  test("--size sets the PNG raster width", async () => {
+    const c = cli(["alain", "-o", "alain.png", "--size", "512"]);
+    expect(await c.run()).toBe(0);
+    expect(text([c.files.get("alain.png")!])).toBe("png@512|<svg>alain|{}</svg>");
+  });
+
+  test("any other extension is an error", async () => {
+    const c = cli(["alain", "-o", "alain.webp"]);
+    expect(await c.run()).toBe(1);
+    expect(c.err.join("")).toContain("must end in .svg or .png");
+    expect(c.files.size).toBe(0);
+  });
+
+  test("a --format contradicting the extension is an error", async () => {
+    const c = cli(["alain", "-o", "alain.png", "--format", "svg"]);
+    expect(await c.run()).toBe(1);
+    expect(c.err.join("")).toContain("contradicts");
+    expect(c.files.size).toBe(0);
+  });
+
+  test("a --format agreeing with the extension is fine", async () => {
+    const c = cli(["alain", "-o", "alain.svg", "--format", "svg"]);
+    expect(await c.run()).toBe(0);
+    expect(c.files.has("alain.svg")).toBe(true);
+  });
+});
+
+describe("PNG on stdout", () => {
+  test("never lands on a TTY", async () => {
+    const c = cli(["alain", "--format", "png"], { tty: true });
+    expect(await c.run()).toBe(1);
+    expect(c.out).toEqual([]);
+    expect(c.err.join("")).toContain("-o");
+  });
+
+  test("flows into a pipe with --format png", async () => {
+    const c = cli(["alain", "--format", "png"], { tty: false });
+    expect(await c.run()).toBe(0);
+    expect(text(c.out)).toBe("png@256|<svg>alain|{}</svg>");
+  });
+
+  test("SVG is fine on a TTY", async () => {
+    const c = cli(["alain"], { tty: true });
+    expect(await c.run()).toBe(0);
+    expect(text(c.out)).toBe("<svg>alain|{}</svg>");
+  });
+});
+
+describe("mode exclusions", () => {
+  const fails = async (argv: string[], fragment: string, stdin?: string) => {
+    const c = cli(argv, { stdin });
+    expect(await c.run()).toBe(1);
+    expect(c.err.join("")).toContain(fragment);
+    expect(c.out).toEqual([]);
+    expect(c.files.size).toBe(0);
+  };
+
+  test("-o and -d are mutually exclusive", () =>
+    fails(["alain", "-o", "a.svg", "-d", "out"], "mutually exclusive"));
+  test("--stdin excludes a positional name", () =>
+    fails(["alain", "--stdin", "-d", "out"], "--stdin"));
+  test("--stdin requires -d", () => fails(["--stdin"], "-d", "alain\n"));
+  test("-d requires --stdin", () => fails(["alain", "-d", "out"], "--stdin"));
+  test("no name and no --stdin is a usage error", () => fails([], "missing name"));
+});
+
+describe("batch", () => {
+  test("one file per name, trimmed, empty lines skipped", async () => {
+    const c = cli(["--stdin", "-d", "blobatars"], { stdin: "alain\n\n  sofia  \nbot-7\n" });
+    expect(await c.run()).toBe(0);
+    expect(c.dirs).toEqual(["blobatars"]);
+    expect([...c.files.keys()].sort()).toEqual([
+      "blobatars/alain.svg",
+      "blobatars/bot-7.svg",
+      "blobatars/sofia.svg",
+    ]);
+    expect(c.files.get("blobatars/alain.svg")).toBe("<svg>alain|{}</svg>");
+    expect(c.out).toEqual([]);
+  });
+
+  test("--format png rasterizes the whole batch", async () => {
+    const c = cli(["--stdin", "-d", "out", "--format", "png", "--size", "64"], {
+      stdin: "alain\n",
+    });
+    expect(await c.run()).toBe(0);
+    expect(text([c.files.get("out/alain.png")!])).toBe("png@64|<svg>alain|{}</svg>");
+  });
+
+  test("filenames are the sanitized identity the render will hash", async () => {
+    const c = cli(["--stdin", "-d", "out"], { stdin: "User@Example.com\n" });
+    expect(await c.run()).toBe(0);
+    // Normalized like the render normalizes, then charset-safe.
+    expect([...c.files.keys()]).toEqual(["out/user_example.com.svg"]);
+  });
+
+  test("--no-normalize keeps the verbatim identity in the filename", async () => {
+    const c = cli(["--stdin", "-d", "out", "--no-normalize"], { stdin: "UserA\n" });
+    expect(await c.run()).toBe(0);
+    expect([...c.files.keys()]).toEqual(["out/UserA.svg"]);
+  });
+
+  test("long names cap at 200 characters plus the extension", async () => {
+    const c = cli(["--stdin", "-d", "out"], { stdin: `${"a".repeat(250)}\n` });
+    expect(await c.run()).toBe(0);
+    const [file] = [...c.files.keys()];
+    expect(file).toBe(`out/${"a".repeat(200)}.svg`);
+  });
+
+  test("an exact duplicate line is one blobatar, not a collision", async () => {
+    const c = cli(["--stdin", "-d", "out"], { stdin: "alain\nalain\n" });
+    expect(await c.run()).toBe(0);
+    expect(c.files.size).toBe(1);
+  });
+
+  test("distinct names mapping to one filename abort before anything is written", async () => {
+    const c = cli(["--stdin", "-d", "out"], { stdin: "sofia\nAlain\nalain\nuser@x\nuser_x\n" });
+    expect(await c.run()).toBe(1);
+    // The error lists every conflicting name; nothing was partially written.
+    const err = c.err.join("");
+    expect(err).toContain("collision");
+    expect(err).toContain("Alain");
+    expect(err).toContain("alain");
+    expect(err).toContain("user@x");
+    expect(err).toContain("user_x");
+    expect(c.files.size).toBe(0);
+    expect(c.dirs).toEqual([]);
+  });
+
+  test("an empty stdin is an error, not a silent success", async () => {
+    const c = cli(["--stdin", "-d", "out"], { stdin: "\n\n" });
+    expect(await c.run()).toBe(1);
+    expect(c.err.join("")).toContain("no names");
+  });
+});
+
+describe("--help and --version", () => {
+  test("--help prints usage to stdout and exits 0", async () => {
+    const c = cli(["--help"]);
+    expect(await c.run()).toBe(0);
+    expect(text(c.out)).toContain("Usage:");
+    expect(c.err).toEqual([]);
+  });
+
+  test("--version prints the version", async () => {
+    const c = cli(["--version"]);
+    expect(await c.run()).toBe(0);
+    expect(text(c.out)).toBe("0.0.0-test\n");
+  });
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // No react here — the root default lists it and this member never renders JSX.
+    "types": ["bun"],
+    // main.ts reads `version` from package.json; the build inlines it.
+    "resolveJsonModule": true
+  },
+  "include": ["src", "test", "scripts"]
+}

--- a/packages/render-core/package.json
+++ b/packages/render-core/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "render-core",
+  "private": true,
+  "//private": "The deliberate exception to \"a Package is publishable\" (CONTEXT.md): a private support package. Never published — wrangler bundles it into the service Worker, and the CLI build inlines it into the distributed output. Its exports map points at TypeScript source because every consumer is a bundler that transpiles.",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "check": "bun test"
+  },
+  "dependencies": {
+    "blobatar": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -1,0 +1,138 @@
+/**
+ * render-core — the shared param table of blobatar's string surfaces.
+ *
+ * The `/v1` URL service and the CLI speak the same six-param vocabulary; this
+ * package is the one place that vocabulary becomes `BlobatarOptions`, with one
+ * set of validation rules and one set of error messages. It contains nothing
+ * else: no rasterization (each consumer brings its own), no cache logic, no
+ * I/O.
+ *
+ * Private and never published — see `package.json` for how each consumer
+ * bundles it.
+ */
+import type { BlobatarOptions, Expression } from "blobatar";
+import { happy, idle, mad, sad } from "blobatar/expression";
+
+/**
+ * The closed allowlist, pre-sorted — the order canonical cache keys serialize
+ * params in. Anything not on this list is not contract surface.
+ */
+export const PARAM_NAMES = [
+  "background",
+  "expression",
+  "hue",
+  "normalize",
+  "size",
+  "tone",
+] as const;
+
+export type ParamName = (typeof PARAM_NAMES)[number];
+
+/**
+ * The table's one default: the PNG raster width when the caller names none.
+ * SVG deliberately has no default — omitted, the markup scales via CSS.
+ */
+export const PNG_DEFAULT_SIZE = 256;
+
+/** Param values as they arrive from a URL query or argv: raw strings. */
+export type RawParams = Partial<Record<ParamName, string>>;
+
+export type ParseResult =
+  | {
+      ok: true;
+      options: BlobatarOptions;
+      /**
+       * The canonical string form of each param that was present — parsed and
+       * re-serialized, so `size=0256` comes back as `"256"`. What a cache key
+       * should embed; policy about *dropping* any of them stays with the
+       * caller.
+       */
+      canonical: Partial<Record<ParamName, string>>;
+    }
+  | { ok: false; error: string };
+
+/**
+ * Digits only — no sign, no decimal point, no exponent, no whitespace. Leading
+ * zeros are tolerated and canonicalized away, so `size=0256` and `size=256`
+ * parse (and cache) identically.
+ */
+const DIGITS = /^[0-9]+$/;
+
+/** Parses an integer within [min, max], or undefined when the string is not one. */
+function integer(value: string, min: number, max: number): number | undefined {
+  if (!DIGITS.test(value)) return undefined;
+  const n = Number(value);
+  return n >= min && n <= max ? n : undefined;
+}
+
+/**
+ * The string half of the glossary rule "an expression is a value a consumer
+ * imports, not a name it spells" — resolved here, in exactly one place, for
+ * every string surface.
+ */
+const EXPRESSIONS: Record<string, Expression> = { happy, sad, mad, idle };
+
+/**
+ * Turns raw string params into `BlobatarOptions`, or one plain-text error.
+ *
+ * Validates in `PARAM_NAMES` order, so the reported error is deterministic
+ * when several params are invalid at once. Only params that are present land
+ * in `options` — an omitted param and its default must stay byte-equivalent.
+ */
+export function parseParams(raw: RawParams): ParseResult {
+  const options: BlobatarOptions = {};
+  const canonical: Partial<Record<ParamName, string>> = {};
+
+  if (raw.background !== undefined) {
+    const background = raw.background;
+    if (background !== "squircle" && background !== "circle" && background !== "square" && background !== "none")
+      return { ok: false, error: "background must be one of: squircle, circle, square, none" };
+    // `none` is the library's own default (`background: false`, transparent) —
+    // the mapping is what makes `background=none` byte-equivalent to omitting.
+    options.background = background === "none" ? false : background;
+    canonical.background = background;
+  }
+
+  if (raw.expression !== undefined) {
+    const expression = EXPRESSIONS[raw.expression];
+    if (!expression)
+      return { ok: false, error: "expression must be one of: happy, sad, mad, idle" };
+    options.expression = expression;
+    canonical.expression = raw.expression;
+  }
+
+  if (raw.hue !== undefined) {
+    const hue = integer(raw.hue, 0, 360);
+    if (hue === undefined)
+      return { ok: false, error: "hue must be an integer between 0 and 360" };
+    options.hue = hue;
+    canonical.hue = String(hue);
+  }
+
+  if (raw.normalize !== undefined) {
+    if (raw.normalize !== "true" && raw.normalize !== "false")
+      return { ok: false, error: "normalize must be true or false" };
+    options.normalize = raw.normalize === "true";
+    canonical.normalize = raw.normalize;
+  }
+
+  if (raw.size !== undefined) {
+    const size = integer(raw.size, 16, 1024);
+    if (size === undefined)
+      return { ok: false, error: "size must be an integer between 16 and 1024" };
+    options.size = size;
+    canonical.size = String(size);
+  }
+
+  if (raw.tone !== undefined) {
+    const tone = integer(raw.tone, 0, 100);
+    if (tone === undefined)
+      return { ok: false, error: "tone must be an integer between 0 and 100" };
+    // The URL speaks 0–100 to stay in integers (a float param would make the
+    // cache key space unbounded); the library speaks 0–1.
+    options.tone = tone / 100;
+    canonical.tone = String(tone);
+  }
+
+  return { ok: true, options, canonical };
+}

--- a/packages/render-core/src/index.ts
+++ b/packages/render-core/src/index.ts
@@ -94,10 +94,12 @@ export function parseParams(raw: RawParams): ParseResult {
   }
 
   if (raw.expression !== undefined) {
-    const expression = EXPRESSIONS[raw.expression];
-    if (!expression)
+    // Own-property check: a plain object answers truthily to "__proto__" and
+    // "constructor", and neither is an Expression — without this, a crafted
+    // URL turns a 400 into a downstream crash.
+    if (!Object.hasOwn(EXPRESSIONS, raw.expression))
       return { ok: false, error: "expression must be one of: happy, sad, mad, idle" };
-    options.expression = expression;
+    options.expression = EXPRESSIONS[raw.expression];
     canonical.expression = raw.expression;
   }
 

--- a/packages/render-core/test/params.test.ts
+++ b/packages/render-core/test/params.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The shared param table — the one place the `/v1` string vocabulary becomes
+ * `BlobatarOptions`. Both the service and the CLI rely on this suite; neither
+ * re-tests the table.
+ */
+import { describe, expect, test } from "bun:test";
+import { happy, idle, mad, sad } from "blobatar/expression";
+
+import { parseParams } from "../src/index";
+
+describe("parseParams", () => {
+  test("no params is valid and sets nothing", () => {
+    const r = parseParams({});
+    expect(r).toEqual({ ok: true, options: {}, canonical: {} });
+  });
+
+  describe("size", () => {
+    test("accepts integers 16–1024", () => {
+      expect(parseParams({ size: "16" })).toEqual({
+        ok: true,
+        options: { size: 16 },
+        canonical: { size: "16" },
+      });
+      expect(parseParams({ size: "1024" })).toEqual({
+        ok: true,
+        options: { size: 1024 },
+        canonical: { size: "1024" },
+      });
+    });
+
+    test("canonicalizes leading zeros", () => {
+      expect(parseParams({ size: "0256" })).toEqual({
+        ok: true,
+        options: { size: 256 },
+        canonical: { size: "256" },
+      });
+    });
+
+    test("rejects out-of-range and non-integer values", () => {
+      const error = "size must be an integer between 16 and 1024";
+      for (const size of ["15", "1025", "0", "1.5", "-64", "+64", "64px", "1e2", "", " 64"]) {
+        expect(parseParams({ size })).toEqual({ ok: false, error });
+      }
+    });
+  });
+
+  describe("background", () => {
+    test("passes shapes through and maps none to false", () => {
+      for (const shape of ["squircle", "circle", "square"] as const) {
+        expect(parseParams({ background: shape })).toEqual({
+          ok: true,
+          options: { background: shape },
+          canonical: { background: shape },
+        });
+      }
+      expect(parseParams({ background: "none" })).toEqual({
+        ok: true,
+        options: { background: false },
+        canonical: { background: "none" },
+      });
+    });
+
+    test("rejects anything else, case-sensitively", () => {
+      const error = "background must be one of: squircle, circle, square, none";
+      for (const background of ["Circle", "SQUARE", "rounded", "true", "false", ""]) {
+        expect(parseParams({ background })).toEqual({ ok: false, error });
+      }
+    });
+  });
+
+  describe("hue", () => {
+    test("accepts integer degrees 0–360", () => {
+      expect(parseParams({ hue: "0" })).toEqual({
+        ok: true,
+        options: { hue: 0 },
+        canonical: { hue: "0" },
+      });
+      expect(parseParams({ hue: "360" })).toEqual({
+        ok: true,
+        options: { hue: 360 },
+        canonical: { hue: "360" },
+      });
+    });
+
+    test("rejects floats and out-of-range degrees", () => {
+      const error = "hue must be an integer between 0 and 360";
+      for (const hue of ["361", "-1", "210.5", "12deg", ""]) {
+        expect(parseParams({ hue })).toEqual({ ok: false, error });
+      }
+    });
+  });
+
+  describe("tone", () => {
+    test("maps integers 0–100 to the library's 0–1 position", () => {
+      expect(parseParams({ tone: "0" })).toEqual({
+        ok: true,
+        options: { tone: 0 },
+        canonical: { tone: "0" },
+      });
+      expect(parseParams({ tone: "40" })).toEqual({
+        ok: true,
+        options: { tone: 0.4 },
+        canonical: { tone: "40" },
+      });
+      expect(parseParams({ tone: "100" })).toEqual({
+        ok: true,
+        options: { tone: 1 },
+        canonical: { tone: "100" },
+      });
+    });
+
+    test("rejects out-of-range and non-integer values", () => {
+      const error = "tone must be an integer between 0 and 100";
+      for (const tone of ["101", "-5", "0.4", ""]) {
+        expect(parseParams({ tone })).toEqual({ ok: false, error });
+      }
+    });
+  });
+
+  describe("expression", () => {
+    test("resolves names to the values the library exports", () => {
+      // Identity, not shape: the glossary's "an expression is a value a
+      // consumer imports, not a name it spells", translated to strings here
+      // and nowhere else.
+      const roster = { happy, sad, mad, idle };
+      for (const [name, value] of Object.entries(roster)) {
+        const r = parseParams({ expression: name });
+        if (!r.ok) throw new Error(r.error);
+        expect(r.options.expression).toBe(value);
+        expect(r.canonical.expression).toBe(name);
+      }
+    });
+
+    test("rejects anything off the roster", () => {
+      const error = "expression must be one of: happy, sad, mad, idle";
+      for (const expression of ["angry", "Happy", "wink", ""]) {
+        expect(parseParams({ expression })).toEqual({ ok: false, error });
+      }
+    });
+  });
+
+  describe("normalize", () => {
+    test("accepts the literals true and false", () => {
+      expect(parseParams({ normalize: "true" })).toEqual({
+        ok: true,
+        options: { normalize: true },
+        canonical: { normalize: "true" },
+      });
+      expect(parseParams({ normalize: "false" })).toEqual({
+        ok: true,
+        options: { normalize: false },
+        canonical: { normalize: "false" },
+      });
+    });
+
+    test("rejects everything else", () => {
+      const error = "normalize must be true or false";
+      for (const normalize of ["1", "0", "yes", "True", ""]) {
+        expect(parseParams({ normalize })).toEqual({ ok: false, error });
+      }
+    });
+  });
+
+  test("params combine, and the first invalid one wins in allowlist order", () => {
+    const r = parseParams({
+      size: "512",
+      background: "circle",
+      hue: "210",
+      tone: "40",
+      expression: "happy",
+      normalize: "false",
+    });
+    if (!r.ok) throw new Error(r.error);
+    expect(r.options).toEqual({
+      size: 512,
+      background: "circle",
+      hue: 210,
+      tone: 0.4,
+      expression: happy,
+      normalize: false,
+    });
+    // Two invalid params, one deterministic message: allowlist order decides
+    // (`hue` sorts before `size`).
+    expect(parseParams({ size: "bad", hue: "bad" })).toEqual({
+      ok: false,
+      error: "hue must be an integer between 0 and 360",
+    });
+  });
+});

--- a/packages/render-core/test/params.test.ts
+++ b/packages/render-core/test/params.test.ts
@@ -137,6 +137,15 @@ describe("parseParams", () => {
         expect(parseParams({ expression })).toEqual({ ok: false, error });
       }
     });
+
+    test("rejects prototype keys — a 400, never a downstream crash", () => {
+      // A plain-object roster answers truthily to "__proto__" and friends;
+      // whatever comes back is not an Expression and would 500 in the render.
+      const error = "expression must be one of: happy, sad, mad, idle";
+      for (const expression of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
+        expect(parseParams({ expression })).toEqual({ ok: false, error });
+      }
+    });
   });
 
   describe("normalize", () => {

--- a/packages/render-core/tsconfig.json
+++ b/packages/render-core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // No react here — the root default lists it and this member never renders.
+    "types": ["bun"]
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
> [!WARNING]
> **Deprecated — kept open for reference only.** The API surface already exists: `apps/site/worker` serves `blobatar.dev/avatar/<name>`, so a second service is the part of this PR that no longer makes sense to merge. What stays useful here as reference: the PNG/resvg-wasm pipeline (verified in workerd, ~950 KB gzip), the `/v1` + immutable + canonical-cache-key design, and the pure-handler testing pattern — all portable into `apps/site/worker` whenever PNG is wanted. **The CLI lives on in #5**, where review continues (the bot findings on shared code were fixed there — `45edb3c`, `ff98a72` — not here).

## What this adds

Three workspace members, one goal: blobatar outside a JS project.

- **`apps/service`** — a dedicated Cloudflare Worker serving `GET /v1/:name.svg` and `GET /v1/:name.png`.
- **`packages/cli`** — publishes as `blobatar-cli` with the bin `blobatar`: SVG/PNG from the terminal, one name or a batch from stdin.
- **`packages/render-core`** — private, never published: the one place the six-param string vocabulary becomes `BlobatarOptions`, shared by both surfaces so validation and error messages cannot drift. `CONTEXT.md` gains the one-line glossary exception for it.

## Heads-up: built in parallel with your worker

Most of this branch predates `feat: adding http blobatars` — I only met `apps/site/worker` when rebasing. Rather than bin it, I'm PRing the complete thing so you can judge both designs side by side. The differences worth naming:

- Dedicated app vs the site's worker; `/v1/:name.svg|png` vs `/avatar/:name`.
- **PNG rasterization via `@resvg/resvg-wasm`** — yours is SVG-only today. Verified inside real workerd: whole bundle ~950 KB gzip against the 3 MB Free limit, wasm initialized once per isolate.
- `Cache-Control: public, max-age=31536000, immutable` under a canonical cache key — the `/v1` path prefix is what makes immutable honest (your `avatar.ts` comment points the same direction).
- Unknown params are ignored and stripped here, vs your documented-or-400 line. Different philosophies; yours is a deliberate design, this one optimizes for pasted URLs accumulating `utm_*` junk without fragmenting the cache.
- The param table predates the 9 new expressions — extending the roster is one line in render-core if any of this survives.

If you'd rather keep your worker as the only public endpoint, happy to slice this differently — e.g. fold the PNG pipeline into `apps/site/worker` and keep just the CLI. Take what's useful.

## The service

```
GET /v1/:name.svg
GET /v1/:name.png?size=512
```

| Param | Values | Default |
|---|---|---|
| `size` | int 16–1024 | PNG `256` · SVG none (attributes only) |
| `background` | `squircle` `circle` `square` `none` | `none` (the library's own default) |
| `hue` | int 0–360 | — |
| `tone` | int 0–100 | — |
| `expression` | `happy` `sad` `mad` `idle` | `idle` |
| `normalize` | `true` `false` | `true` |

- Invalid values → plain-text 400 **before any rendering**; malformed percent-encoding is caught (400, not 500); names cap at 256 chars; empty-after-normalize → 400. All non-image responses are `no-store`.
- Deliberately not params, with reasons in the README: `palette` (bypasses the contrast guarantee), `traits` (unbounded frozen surface), `animate` (hover can't reach inside a remote `<img>`), `title` (the host page's `alt` owns accessibility).
- **Canonical cache key**: synthetic fixed origin (the serving hostname never fragments the render cache), name keyed exactly as the library will hash it (NFC+trim+lowercase; verbatim under `normalize=false`), allowlisted params only, sorted, stripped when byte-equivalent to their absence (`expression=idle`, `normalize=true`, `background=none`, `size=256` on PNG). Cache writes ride `waitUntil`.
- Headers: CSP `default-src 'none'; style-src 'unsafe-inline'` + `nosniff` on SVG; the router matches on path only, so the Worker mounts on any hostname without a code change.
- Structure: one pure handler behind injected capabilities (cache, waitUntil, render, rasterize) + a branch-free CF entry. Every branch is testable under `bun test` — no second test framework, per the repo rule.

## The CLI

```
blobatar <name>                      # SVG to stdout
blobatar <name> -o alain.png --size 512
blobatar --stdin -d ./blobatars/    # batch: one name per line
```

- Flags mirror `/v1` through render-core — identical validation, identical messages.
- SVG to stdout by default; PNG never lands on a TTY (`-o`, or pipe + `--format png`); with `-o` the extension decides and a contradicting `--format` errors.
- Batch: deterministic filenames (the render's own normalization, then `[^A-Za-z0-9._-]` → `_`, capped at 200); every filename is precomputed and a collision aborts the whole batch listing the conflicting names — nothing partially written.
- Plain-Node portable source (`#!/usr/bin/env node`, Node ≥ 18) — a deliberate, documented exception to the repo's Bun-first rule, because npx is where the non-JS-project audience lives. `bunx` works too.
- Published as plain JS with render-core inlined at build; runtime deps are exactly `blobatar` + `@resvg/resvg-js` (napi prebuilds, no postinstall).
- Determinism promise, stated honestly in the README: SVG byte-identical per visual-contract major; PNG bytes tied to the resvg version in the lockfile.

## Testing

- 66 tests across the three members (param table in render-core; the handler hit with `Request`→`Response` through ~20-line fakes; the CLI's whole flag/output/batch matrix through an injected process seam), plus a smoke script that spawns the built bin under Node — same pattern as the library package's own `smoke.mjs`.
- Everything runs inside `bun --filter '*' check`. Full workspace after rebase: 242 pass, 0 fail.
- Manually verified end-to-end under `wrangler dev`: SVG/PNG bytes, 400/404/405, headers. (wrangler needs Node ≥ 22 on the machine; `bun run dev` builds the library first because wrangler bundles workspace deps through their real exports maps.)

## Open questions

- Is `blobatar-cli` the name you want? The npm name is free, and the `@blobatar` scope is unclaimed if you'd rather have an org.
- If the dedicated-app design survives: which hostname? If not: which pieces do you want folded into `apps/site/worker` — the PNG pipeline is the obvious candidate.
