### PR TITLE
fix: reject prototype keys in the worker's param tables

### DIFF
--- a/apps/site/worker/params.test.ts
+++ b/apps/site/worker/params.test.ts
@@ -45,6 +45,16 @@ test("the roster is exactly the thirteen poses", () => {
   bad(() => opts("expression=bakePose"));
 });
 
+test("prototype keys are not poses either", () => {
+  // `"__proto__" in table` is true — `in` walks the prototype chain — so these
+  // used to come back as Object.prototype and friends, which are not
+  // Expressions and crash the render: a caller typo served as a 500.
+  bad(() => opts("expression=__proto__"));
+  bad(() => opts("expression=constructor"));
+  bad(() => opts("expression=toString"));
+  bad(() => opts("background=__proto__"));
+});
+
 test("an undocumented parameter is an error, not a silent drop", () => {
   // The failure this exists for: a typo renders a valid blobatar wearing the
   // wrong face, and the caller has nothing to notice.

--- a/apps/site/worker/params.ts
+++ b/apps/site/worker/params.ts
@@ -81,9 +81,12 @@ function number(raw: string, key: string, min: number, max: number): number {
 }
 
 function oneOf<T>(raw: string, key: string, table: Record<string, T>): T {
-  // `in` rather than a truthy lookup: `background=none` maps to `false`, and a
-  // truthiness check would reject the one value that has to be falsy.
-  if (!(raw in table)) {
+  // An own-property check rather than `in` or a truthy lookup. `in` walks the
+  // prototype chain, so "__proto__" and "constructor" passed and handed back
+  // Object.prototype — not a value of the table, and a crash downstream. A
+  // truthiness check would reject the one value that has to be falsy
+  // (`background=none` maps to `false`).
+  if (!Object.hasOwn(table, raw)) {
     throw new BadRequest(`unknown ${key} "${raw}" — expected one of ${Object.keys(table).join(", ")}`);
   }
   return table[raw]!;


### PR DESCRIPTION
The one-line fix promised in [the #4 thread](https://github.com/Alain00/blobatar/pull/4#discussion_r3802032863), as its own PR so it does not wait on any design discussion.

`oneOf` validates with `raw in table`, and `in` walks the prototype chain — so `/avatar/x?expression=__proto__` passes the roster, `opts.expression` becomes `Object.prototype`, and the render crashes when it calls `e.vars(...)`. The `catch` only handles `BadRequest`, so a caller typo is served as a 500 today. `background=__proto__` slips through the same way (milder: it renders the default backdrop).

Fix: `Object.hasOwn` instead of `in` — same helper, so both tables are covered at once — keeping the original reason `in` was chosen (`background=none` maps to `false`, so a truthy lookup is still wrong). Regression cases added next to the roster test: `__proto__`, `constructor`, `toString`, and `background=__proto__` all land on the usual 400.

Worker suite: 46 pass. Nothing else touched.