### PR TITLE
feat: add a Vue 3 adapter (blobatar/vue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ import { Blobatar } from "blobatar/react";
 Everything but `name` is optional. Remaining props land on the underlying
 element, so `className`, `alt` and the rest behave as you would expect.
 
+### Vue
+
+```html
+<script setup>
+import { Blobatar } from "blobatar/vue";
+</script>
+
+<template>
+  <Blobatar name="alain@example.com" :size="48" />
+</template>
+```
+
+The same props and the same behavior as the React adapter. Anything not
+declared as a prop lands on the underlying element, so `class`, `style`, `alt`
+and the rest behave as you would expect.
+
 ### Anywhere else
 
 `blobatar()` returns SVG markup as a string, and `blobatarUri()` wraps it in a
@@ -50,9 +66,9 @@ import { blobatar } from "blobatar/blob";
 
 ### Configuring
 
-Options are the same for both APIs. `background`, `hue` and `tone` cover the
-common cases; `traits` pins any individual axis as the 0–1 position the hash
-would otherwise have produced:
+Options are the same across the React, Vue and string APIs. `background`, `hue`
+and `tone` cover the common cases; `traits` pins any individual axis as the 0–1
+position the hash would otherwise have produced:
 
 ```tsx
 <Blobatar name={user.email} background="circle" hue={210} size={48} />;
@@ -81,6 +97,8 @@ import "blobatar/motion.css"; // required — nothing animates without it
 
 <Blobatar name={user.email} animate="hover" expression={happy} size={64} />;
 ```
+
+The same props work with `blobatar/vue` — only the component import changes.
 
 `animate` changes the rendering mode: a static blobatar is a single `<img>`, an
 animated one is inline SVG. Use `"hover"` in a grid and `"always"` for the

--- a/bun.lock
+++ b/bun.lock
@@ -77,12 +77,15 @@
         "@types/react-dom": "^19",
         "react": "^19",
         "react-dom": "^19",
+        "vue": "^3.5.0",
       },
       "peerDependencies": {
         "react": ">=18",
+        "vue": ">=3",
       },
       "optionalPeers": [
         "react",
+        "vue",
       ],
     },
   },
@@ -571,6 +574,24 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.41", "https://registry.npmmirror.com/@vue/compiler-core/-/compiler-core-3.5.41.tgz", { "dependencies": { "@babel/parser": "^7.29.8", "@vue/shared": "3.5.41", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.41", "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz", { "dependencies": { "@vue/compiler-core": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.41", "https://registry.npmmirror.com/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz", { "dependencies": { "@babel/parser": "^7.29.8", "@vue/compiler-core": "3.5.41", "@vue/compiler-dom": "3.5.41", "@vue/compiler-ssr": "3.5.41", "@vue/shared": "3.5.41", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.19", "source-map-js": "^1.2.1" } }, "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.41", "https://registry.npmmirror.com/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz", { "dependencies": { "@vue/compiler-dom": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.41", "https://registry.npmmirror.com/@vue/reactivity/-/reactivity-3.5.41.tgz", { "dependencies": { "@vue/shared": "3.5.41" } }, "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.41", "https://registry.npmmirror.com/@vue/runtime-core/-/runtime-core-3.5.41.tgz", { "dependencies": { "@vue/reactivity": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.41", "https://registry.npmmirror.com/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz", { "dependencies": { "@vue/reactivity": "3.5.41", "@vue/runtime-core": "3.5.41", "@vue/shared": "3.5.41", "csstype": "^3.2.3" } }, "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.41", "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.41.tgz", { "dependencies": { "@vue/compiler-ssr": "3.5.41", "@vue/runtime-dom": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ=="],
+
+    "@vue/shared": ["@vue/shared@3.5.41", "https://registry.npmmirror.com/@vue/shared/-/shared-3.5.41.tgz", {}, "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA=="],
+
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
     "@webassemblyjs/floating-point-hex-parser": ["@webassemblyjs/floating-point-hex-parser@1.13.2", "", {}, "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="],
@@ -689,7 +710,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "https://registry.npmmirror.com/entities/-/entities-7.0.1.tgz", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -710,6 +731,8 @@
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -780,6 +803,8 @@
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
     "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+
+    "magic-string": ["magic-string@0.30.21", "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mediabunny": ["mediabunny@1.50.8", "", { "dependencies": { "@types/dom-mediacapture-transform": "^0.1.11", "@types/dom-webcodecs": "0.1.13" } }, "sha512-LgykLyQzhdpo0V2yw3UXmOpj+b4JAGdpHBwsPE6kjSt8Za0d1VllD+FV7EGHBcdV4+oHUAo+yrqbVAWxNSDCPQ=="],
 
@@ -939,6 +964,8 @@
 
     "video": ["video@workspace:apps/video"],
 
+    "vue": ["vue@3.5.41", "https://registry.npmmirror.com/vue/-/vue-3.5.41.tgz", { "dependencies": { "@vue/compiler-dom": "3.5.41", "@vue/compiler-sfc": "3.5.41", "@vue/runtime-dom": "3.5.41", "@vue/server-renderer": "3.5.41", "@vue/shared": "3.5.41" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg=="],
+
     "watchpack": ["watchpack@2.5.2", "", { "dependencies": { "graceful-fs": "^4.1.2" } }, "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg=="],
 
     "webpack": ["webpack@5.105.0", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.15.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.28.1", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.19.0", "es-module-lexer": "^2.0.0", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.3.1", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.3", "tapable": "^2.3.0", "terser-webpack-plugin": "^5.3.16", "watchpack": "^2.5.1", "webpack-sources": "^3.3.3" }, "peerDependencies": { "webpack-cli": "*" }, "optionalPeers": ["webpack-cli"], "bin": { "webpack": "bin/webpack.js" } }, "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw=="],
@@ -993,6 +1020,12 @@
 
     "@svgr/hast-util-to-babel-ast/@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
+    "@svgr/hast-util-to-babel-ast/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "@vue/compiler-core/@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@vue/compiler-sfc/@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
     "css-loader/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
@@ -1008,6 +1041,10 @@
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@vue/compiler-core/@babel/parser/@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@vue/compiler-sfc/@babel/parser/@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 

--- a/packages/blobatar/README.md
+++ b/packages/blobatar/README.md
@@ -14,6 +14,16 @@ import { Blobatar } from "blobatar/react";
 <Blobatar name={user.email} size={48} />;
 ```
 
+```html
+<script setup>
+import { Blobatar } from "blobatar/vue";
+</script>
+
+<template>
+  <Blobatar name="alain@example.com" :size="48" />
+</template>
+```
+
 A blobatar always stands for somebody — a user, a bot, a team, a repo — so the
 value it is generated from is that somebody's `name`: a username, a display
 name, an email, a handle, an id. Any string works and the same string always
@@ -149,6 +159,17 @@ import "blobatar/motion.css"; // required — nothing animates without it
 <Blobatar name={user.email} animate="hover" size={48} />;
 ```
 
+```html
+<script setup>
+import { Blobatar } from "blobatar/vue";
+import "blobatar/motion.css"; // required — nothing animates without it
+</script>
+
+<template>
+  <Blobatar name="alain@example.com" animate="hover" :size="48" />
+</template>
+```
+
 **Turning this on changes the rendering mode, and that is not free.** A static
 blobatar is a single `<img>`; an animated one is inline SVG, roughly a dozen DOM
 nodes. Content inside an `<img>` is an isolated document that `:hover` cannot
@@ -168,11 +189,12 @@ pixel. It is worth the most on a profile header, which is what `"always"` is
 for. Eyes may cross outside the body outline on a hard glance; that is intended,
 and reads as a face turning rather than as a bug.
 
-Currently `blobatar/react` only. The string API still returns static markup:
+Currently `blobatar/react` and `blobatar/vue` only. The string API still returns static markup:
 supporting `animate` there means every consumer of `blobatar()` carries the motion
 code whether they animate or not, which is a real cost for a feature most
-callers will never use. If you need animated markup without React, open an issue
-— it wants its own entry point rather than a branch inside `blobatar()`.
+callers will never use. If you need animated markup without either framework,
+open an issue — it wants its own entry point rather than a branch inside
+`blobatar()`.
 
 ## Expressions
 
@@ -213,6 +235,9 @@ you hold, not an animation you fire. Without the stylesheet, or under
 `prefers-reduced-motion`, it holds one frame of that swing, which still reads as
 a creature with its attention somewhere else. Whatever it is waiting on still
 needs to be announced somewhere real in your DOM — the face is decoration.
+
+The same values work with `blobatar/vue`; only the import of the component
+itself changes.
 
 The first expression you import costs about 340 bytes (the shared serializer and
 bake, paid once) and each untinted one after it about 35. The four tinted poses —

--- a/packages/blobatar/docs/motion-spec.md
+++ b/packages/blobatar/docs/motion-spec.md
@@ -609,6 +609,26 @@ consequences worth stating, because both were learned the hard way:
 This is the bulk of the implementation work and none of it is CSS. Budget for it
 accordingly.
 
+### 7.2 The Vue adapter
+
+`blobatar/vue` renders the same two modes with the same `makeParts` split — `cls`
+and `vars` on the outer element, `inner` through `innerHTML` on the root `<g>`.
+Two React-specific memoizations do not carry over, because Vue's reactivity
+replaces them:
+
+- The serialized dependency string (`JSON.stringify` with `generation?.id`) is
+  unnecessary: a `computed` tracks the props it reads, and `generation` is
+  tracked by reference, which is the exact granularity the string was
+  approximating.
+- The memoized `{__html}` object is unnecessary: the VNode diff compares prop
+  values, so a byte-identical `innerHTML` is never rewritten and the DOM below
+  the root survives an expression change — the same property React needs the
+  memo to fake.
+
+The `<title>`, backdrop and root class are still real children/attributes
+(never part of `inner`), because the geometric argument — the plate must not
+lift with the creature, `<title>` must name the `<svg>` — is framework-neutral.
+
 ---
 
 ## 8. Considered and rejected

--- a/packages/blobatar/package.json
+++ b/packages/blobatar/package.json
@@ -15,6 +15,7 @@
     "./uri": { "types": "./dist/uri.d.ts", "default": "./dist/uri.js" },
     "./expression": { "types": "./dist/expression.d.ts", "default": "./dist/expression.js" },
     "./react": { "types": "./dist/react.d.ts", "default": "./dist/react.js" },
+    "./vue": { "types": "./dist/vue.d.ts", "default": "./dist/vue.js" },
     "./motion.css": "./dist/motion.css",
     "./package.json": "./package.json"
   },
@@ -33,17 +34,20 @@
     "prepack": "bun run build"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "vue": ">=3"
   },
   "peerDependenciesMeta": {
-    "react": { "optional": true }
+    "react": { "optional": true },
+    "vue": { "optional": true }
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "vue": "^3.5.0"
   },
   "keywords": ["blobatar", "avatar", "identicon", "svg", "deterministic", "no-dependencies"],
   "license": "MIT",

--- a/packages/blobatar/scripts/build.ts
+++ b/packages/blobatar/scripts/build.ts
@@ -28,6 +28,7 @@ const ENTRIES = [
   "src/uri.ts",
   "src/expression.ts",
   "src/react.tsx",
+  "src/vue.ts",
 ];
 
 rmSync("dist", { recursive: true, force: true });
@@ -39,9 +40,9 @@ const build = await Bun.build({
   format: "esm",
   minify: true,
   sourcemap: "linked",
-  // React is a peer dependency and an optional one: never inline it, and never
-  // let the JSX runtime import get rewritten into the bundle either.
-  external: ["react", "react/jsx-runtime", "react/jsx-dev-runtime"],
+  // React and Vue are peer dependencies and optional ones: never inline them,
+  // and never let the JSX runtime import get rewritten into the bundle either.
+  external: ["react", "react/jsx-runtime", "react/jsx-dev-runtime", "vue"],
   // What selects the JSX runtime. Bun reads `process.env.NODE_ENV` to choose
   // between `jsx` and `jsxDEV`, and a publish build run from a normal shell has
   // it unset — so without this the package shipped `react/jsx-dev-runtime`

--- a/packages/blobatar/scripts/size.ts
+++ b/packages/blobatar/scripts/size.ts
@@ -131,6 +131,24 @@ const ENTRIES: {
              globalThis.x = blobatar(String(globalThis.seed), { expression: happy });`,
   },
   {
+    // The Vue adapter, measured against "react" above. Same two rendering
+    // modes and the same parts builder; the Vue one swaps the JSX branch for
+    // `h()` calls and Vue's fine-grained reactivity for the React memo tricks
+    // (no serialized dependency string, no memoized `{__html}`).
+    //
+    // It still lands ~170 B over React: the runtime props table (12 declared
+    // props — React's are type-level only), the string-style merge for
+    // templates that pass `style="…"`, and the `animate` boolean shorthand
+    // normalization. All three are Vue surface, not motion; none of them would
+    // shrink if the animation layer got smaller. `vue` is external, like
+    // `react`. Measured 5493 against react 5326 on the v2 core.
+    name: "vue",
+    budget: 5550,
+    external: ["vue"],
+    source: `import { Blobatar } from "../../src/vue";
+             globalThis.x = Blobatar;`,
+  },
+  {
     name: "traits only",
     budget: 600,
     external: [],

--- a/packages/blobatar/scripts/smoke.mjs
+++ b/packages/blobatar/scripts/smoke.mjs
@@ -16,12 +16,15 @@ import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { h } from "vue";
+import { renderToString } from "vue/server-renderer";
 
 import { blobatar, palette, traits, normalizeSeed } from "blobatar";
 import { blobatar as blob } from "blobatar/blob";
 import { blobatarUri } from "blobatar/uri";
 import * as poses from "blobatar/expression";
 import { Blobatar } from "blobatar/react";
+import { Blobatar as VueBlobatar } from "blobatar/vue";
 
 let failed = false;
 
@@ -83,6 +86,25 @@ check("blobatar/react animated", () => {
   );
   assert(html.includes("<svg"), "animated mode did not render inline SVG");
   assert(html.includes("mo-root"), "animated mode emitted no motion class");
+  return "inline SVG with motion classes";
+});
+
+// `renderToString` is async, so the markup is prepared outside `check` and the
+// synchronous assertions run on the resolved strings.
+const vueStatic = await renderToString(h(VueBlobatar, { name: "alain", size: 48 }));
+check("blobatar/vue", () => {
+  assert(vueStatic.includes("<img"), `static mode did not render an <img>: ${vueStatic.slice(0, 60)}`);
+  assert(vueStatic.includes("data:image/svg+xml"), "static mode rendered no blobatar");
+  return "renders on the server";
+});
+
+const vueAnimated = await renderToString(
+  h(VueBlobatar, { name: "alain", size: 48, animate: "always" }),
+);
+check("blobatar/vue animated", () => {
+  assert(vueAnimated.includes("<svg"), "animated mode did not render inline SVG");
+  assert(vueAnimated.includes("mo-root"), "animated mode emitted no motion class");
+  assert(vueAnimated.includes("--mo-phase"), "animated mode emitted no seeded timing");
   return "inline SVG with motion classes";
 });
 

--- a/packages/blobatar/src/render.ts
+++ b/packages/blobatar/src/render.ts
@@ -51,13 +51,14 @@ export interface BlobatarOptions {
    *
    * Requires `import "blobatar/motion.css"`, and requires the blobatar to be
    * inline SVG — content inside an `<img>` is an isolated document that hover
-   * cannot reach. `blobatar/react` switches rendering mode for you; the string
-   * API is already inline.
+   * cannot reach. `blobatar/react` and `blobatar/vue` switch rendering mode
+   * for you; the string API is already inline.
    *
-   * **Honored by `blobatar/react` only, for now.** `blobatar()` returns static
-   * markup regardless: a branch on `animate` inside it keeps the motion module
-   * alive for every caller, animating or not, which measured at ~190 B. An
-   * animated string API wants its own entry point, not a branch here.
+   * **Honored by the framework adapters (`blobatar/react`, `blobatar/vue`)
+   * only.** `blobatar()` returns static markup regardless: a branch on
+   * `animate` inside it keeps the motion module alive for every caller,
+   * animating or not, which measured at ~190 B. An animated string API wants
+   * its own entry point, not a branch here.
    */
   animate?: Animate;
   /**
@@ -164,9 +165,10 @@ export interface Backdrop {
 /**
  * The backdrop is the style's concern to default, not the renderer's.
  *
- * Returns the path rather than a serialized `<path>` because the React adapter
- * has to draw it as a real element: it sits *outside* the motion root, so it
- * cannot ride along in the innerHTML string that the root `<g>` now owns.
+ * Returns the path rather than a serialized `<path>` because the framework
+ * adapters (React, Vue) have to draw it as a real element: it sits *outside*
+ * the motion root, so it cannot ride along in the innerHTML string that the
+ * root `<g>` now owns.
  */
 function backdrop<L>(
   style: Style<L>,
@@ -241,22 +243,23 @@ export function makeBlobatar<L>(style: Style<L>) {
 /**
  * The blobatar in the pieces a renderer that owns the outer element needs.
  *
- * Split out from `makeBlobatar` because the React adapter has to own the `<svg>`
- * when animating — it needs real JSX props on it — and recovering the inner
- * markup by regex-stripping a serialized `<svg>` is the kind of thing that
- * works until someone passes a `title` containing a `>`.
+ * Split out from `makeBlobatar` because the framework adapters (React, Vue)
+ * have to own the `<svg>` when animating — they need real element props on it
+ * — and recovering the inner markup by regex-stripping a serialized `<svg>` is
+ * the kind of thing that works until someone passes a `title` containing a `>`.
  *
  * The split runs one level deeper than that, and this is the load-bearing part:
  * **nothing that varies with `expression` may appear in `inner`.** `inner` is
- * handed to `dangerouslySetInnerHTML`, so a single byte of drift makes React
- * replace the whole subtree — and a brand-new element has no previous computed
- * value, which is precisely the rule that stops transitions running on first
- * style resolution. The morph would not be slow or wrong; it would not exist,
- * and every idle animation underneath would restart from phase zero on top of
- * it. So the root class lives in `cls` and the pose lives in `vars`, both of
- * which land on real attributes that React can diff in place, and the backdrop
- * comes back as geometry because it belongs outside the root `<g>` — a plate
- * that hover-lifts with the creature stops being a plate.
+ * handed to `dangerouslySetInnerHTML`/`innerHTML`, so a single byte of drift
+ * makes the adapter replace the whole subtree — and a brand-new element has no
+ * previous computed value, which is precisely the rule that stops transitions
+ * running on first style resolution. The morph would not be slow or wrong; it
+ * would not exist, and every idle animation underneath would restart from
+ * phase zero on top of it. So the root class lives in `cls` and the pose lives
+ * in `vars`, both of which land on real attributes that the adapter can diff
+ * in place, and the backdrop comes back as geometry because it belongs outside
+ * the root `<g>` — a plate that hover-lifts with the creature stops being a
+ * plate.
  *
  * `test/expression.test.ts` pins the invariant directly.
  */

--- a/packages/blobatar/src/vue.ts
+++ b/packages/blobatar/src/vue.ts
@@ -1,0 +1,194 @@
+import {
+  computed,
+  defineComponent,
+  h,
+  type CSSProperties,
+  type PropType,
+} from "vue";
+import { serializeVars, type Animate } from "./animate";
+import { _parts, type BlobatarOptions } from "./blobatar";
+import type { Palette } from "./color";
+import type { Expression } from "./expression";
+import type { TraitOverrides } from "./traits";
+import { blobatarUri } from "./uri";
+
+/**
+ * Vue 3 adapter: the same two rendering modes as `blobatar/react`, behind the
+ * same props.
+ *
+ * Static blobatars render as an `<img>`: a list of a few hundred is exactly the
+ * case where you do not want extra DOM nodes per screen, and nothing here uses
+ * `currentColor`, so inline SVG would buy nothing.
+ *
+ * Animated blobatars cannot. Content inside an `<img>` is an isolated,
+ * non-interactive document — `:hover` never fires inside it and host-page CSS
+ * cannot reach the shapes — so `animate` switches to inline SVG and costs
+ * roughly a dozen nodes per blobatar. That trade is the reason animation is
+ * opt-in rather than a default. See `react.tsx` for the full argument; none of
+ * it is framework-specific.
+ *
+ * A render function rather than a template or an SFC: the same `setup()` then
+ * works in `<script setup>`, in a plain `setup()` return, and under
+ * `defineComponent` — no template compiler in the loop, and no SFC pre-step for
+ * a consumer to configure. Vue's `h()` renders real SVG elements natively, so
+ * there is no JSX runtime to externalize either.
+ *
+ * Everything not declared as a prop — `class`, `style`, `alt`, `aria-*`,
+ * event listeners, `data-*` — flows through Vue's `attrs` onto whichever
+ * element the mode renders, the same way `rest` spreads onto the DOM node in
+ * the React adapter.
+ */
+export const Blobatar = defineComponent({
+  name: "Blobatar",
+  // Attrs are placed by hand on whichever element the mode renders; the
+  // default automatic inheritance can only target one fixed element, so it is
+  // off. The two branches handle their own merge.
+  inheritAttrs: false,
+  props: {
+    /** Who the blobatar is for. A username, a display name, an email — any
+     *  string, and the same string always renders the same blobatar. */
+    name: { type: String, required: true },
+    /** Emits width/height attributes. Omit to let CSS size it. */
+    size: { type: Number },
+    /** Overrides the default backdrop. `false` renders transparent. */
+    background: {
+      type: [Boolean, String] as PropType<BlobatarOptions["background"]>,
+    },
+    /** Overrides specific palette entries. */
+    palette: { type: Object as PropType<Palette> },
+    /** Locks the hue in degrees, so the name drives shape only. */
+    hue: { type: Number },
+    /** Locks the tone as a 0–1 position in the swatch set. */
+    tone: { type: Number },
+    /** Pins individual traits, so the name drives only what you leave out. */
+    traits: { type: Object as PropType<TraitOverrides> },
+    /** Applies NFC + trim + lowercase to the name. Default true. */
+    normalize: { type: Boolean, default: true },
+    /** Enforces the minimum contrast ratios. Default true. */
+    contrast: { type: Boolean, default: true },
+    /** Adds a `<title>` for screen readers. */
+    title: { type: String },
+    /**
+     * Idle animation. Off by default; `"hover"` or `"always"`.
+     *
+     * Requires `import "blobatar/motion.css"`, and switches the rendering mode
+     * to inline SVG — the same contract as `blobatar/react`.
+     *
+     * Boolean is accepted alongside the two modes for template shorthand
+     * (`<Blobatar animate />`), which Vue coerces to `true`; it means the same
+     * as `"hover"`.
+     */
+    animate: { type: [String, Boolean] as PropType<Animate | false> },
+    /** Which pose the blobatar holds. Import one from `blobatar/expression`. */
+    expression: { type: Object as PropType<Expression> },
+  },
+  setup(props, { attrs }) {
+    /**
+     * The options object, rebuilt whenever any option changes.
+     *
+     * React's adapter memoizes on a serialized dependency string because its
+     * hooks have no way to track each option individually. Vue does not need
+     * that dance at all: `computed` tracks the props it reads by reference, so
+     * an option that changed recomputes and one that did not invalidates
+     * nothing. That is the correct granularity, which the serialized string
+     * was approximating.
+     */
+    const opts = computed<BlobatarOptions>(() => ({
+      size: props.size,
+      background: props.background,
+      palette: props.palette,
+      hue: props.hue,
+      tone: props.tone,
+      normalize: props.normalize,
+      contrast: props.contrast,
+      title: props.title,
+      expression: props.expression,
+      traits: props.traits,
+    }));
+
+    const animated = computed(() => !!props.animate);
+
+    const src = computed(() =>
+      animated.value ? "" : blobatarUri(props.name, opts.value),
+    );
+
+    const parts = computed(() =>
+      animated.value
+        ? _parts(props.name, {
+            ...opts.value,
+            // `true` (template shorthand) means the same as "hover".
+            animate: props.animate === "always" ? "always" : "hover",
+          })
+        : null,
+    );
+
+    return () => {
+      const o = opts.value;
+      const p = parts.value;
+
+      if (p) {
+        const { style: userStyle, ...svgAttrs } = attrs as {
+          style?: CSSProperties | string;
+          [key: string]: unknown;
+        };
+        // The seeded motion custom properties go on the same element the
+        // stylesheet reads them from. Vue accepts style as a string or an
+        // object; a string cannot be merged by spread, so it is concatenated —
+        // user declarations last, so they win over the seed, exactly like the
+        // object path and like React's `{ ...vars, ...style }`.
+        const vars = p.vars ?? {};
+        const style =
+          typeof userStyle === "string"
+            ? serializeVars(vars) + (userStyle ? `;${userStyle}` : "")
+            : { ...vars, ...(userStyle ?? {}) };
+
+        return h(
+          "svg",
+          {
+            ...svgAttrs,
+            xmlns: "http://www.w3.org/2000/svg",
+            viewBox: "0 0 100 100",
+            ...(o.size !== undefined ? { width: o.size, height: o.size } : {}),
+            // With a `title` the markup carries a `<title>`, so this is a
+            // labelled image; without one it is decoration and should be
+            // skipped entirely — the same call `alt=""` makes on the `<img>`
+            // path. Never both: a `role="img"` that is also `aria-hidden`
+            // just contradicts itself.
+            role: o.title ? "img" : undefined,
+            "aria-hidden": o.title ? undefined : true,
+            style,
+          },
+          [
+            /*
+             * Three real children rather than one innerHTML blob, for the same
+             * reason as the React adapter: `<title>` names the element it is
+             * the first child of, the backdrop must sit outside the hover-lift
+             * or the plate scales with the creature, and only the root `<g>`'s
+             * class varies at runtime.
+             *
+             * Vue needs no memoized `{__html}` object here. The VNode diff
+             * compares prop values, and `inner` never varies with the
+             * expression — so an expression change is attribute writes on the
+             * root and the DOM below survives, which is what the morph needs
+             * to exist at all.
+             */
+            o.title ? h("title", o.title) : null,
+            p.bg ? h("path", { d: p.bg.d, fill: p.bg.fill }) : null,
+            h("g", { class: p.cls, innerHTML: p.inner }),
+          ],
+        );
+      }
+
+      const { alt, ...imgAttrs } = attrs as {
+        alt?: string;
+        [key: string]: unknown;
+      };
+      return h("img", {
+        src: src.value,
+        ...(o.size !== undefined ? { width: o.size, height: o.size } : {}),
+        alt: alt ?? o.title ?? "",
+        ...imgAttrs,
+      });
+    };
+  },
+});


### PR DESCRIPTION
## Summary

Adds a Vue 3 adapter, `blobatar/vue`, mirroring the `blobatar/react` component: a static `<img>` by default, inline SVG when `animate` is set — with the same options, the same attrs passthrough, and the same accessibility handling (`title` → `role="img"` + `<title>`; otherwise `aria-hidden`).

## Motivation

The React adapter is the only framework integration today. This adds parity for Vue 3 `<script setup>` users without touching the core renderer — the adapter consumes the existing `_parts` seam exactly like React does.

## What changed

- `packages/blobatar/src/vue.ts` — `defineComponent` + `setup()` render-function component. Vue's fine-grained reactivity replaces the React-specific memoization (serialized dep string, memoized `{__html}`): a `computed` tracks the props it reads by reference, and the VNode diff only rewrites `innerHTML` when the string actually changes, so an expression change stays attribute writes on the root `<g>`.
- Package wiring — `blobatar/vue` export, optional `vue >= 3` peer dependency, build entry + external, size-gate entry, and smoke checks that render both modes through `vue/server-renderer` against the built `dist`.
- Docs — root and package READMEs (usage + animation examples) and `docs/motion-spec.md` §7.2 explaining the adapter.

The branch is rebased onto current `main` (Blobatar 2), so the adapter matches the v2 API: no `generation` option, same remaining options as the React adapter.

## Testing

- `bun test` — 128 pass.
- `bun run size` — every entry within budget (`vue` 5493 / 5550 B gz, `react` 5326 / 5370).
- `bun run build` — emits `dist/vue.js` plus declarations; the new adapter type-checks.
- `bun run smoke` — both `blobatar/vue` modes render under Node from the published entry.

The composition probe remains React-specific for now; a browser-level Vue harness (expression change must not rebuild the DOM) is a natural follow-up.