### PR TITLE
feat: add Svelte, Solid, and Preact adapters

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -12,12 +12,14 @@
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.23",
+    "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-slider": "^1.4.7",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "blobatar": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.3.1",
+    "lucide-react": "^1.33.0",
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^3.0.1"

--- a/apps/site/src/Editor.tsx
+++ b/apps/site/src/Editor.tsx
@@ -4,6 +4,13 @@ import { traits as reader, type TraitOverrides } from "blobatar";
 import { Control } from "@/components/editor/control";
 import { ShapePicker, TonePicker } from "@/components/editor/pickers";
 import { Segmented, SegmentedItem } from "@/components/ui/segmented";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Snippet } from "@/components/ui/snippet";
 import { Install } from "@/components/ui/install";
 import {
@@ -215,16 +222,20 @@ export function Editor() {
         >
           <div className="text-muted flex items-baseline justify-between gap-4 text-xs lowercase">
             <span>your config</span>
-            <Segmented
-              type="single"
-              value={api}
-              onValueChange={(v: string) => v && setApi(v as Api)}
-              aria-label="API"
-            >
-              <SegmentedItem value="react">react</SegmentedItem>
-              <SegmentedItem value="string">string</SegmentedItem>
-              <SegmentedItem value="http">http</SegmentedItem>
-            </Segmented>
+            <Select value={api} onValueChange={v => v && setApi(v as Api)}>
+              <SelectTrigger aria-label="API" className="w-auto">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="react">react</SelectItem>
+                <SelectItem value="vue">vue</SelectItem>
+                <SelectItem value="svelte">svelte</SelectItem>
+                <SelectItem value="solid">solid</SelectItem>
+                <SelectItem value="preact">preact</SelectItem>
+                <SelectItem value="string">string</SelectItem>
+                <SelectItem value="http">http</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           {/*

--- a/apps/site/src/components/ui/select.tsx
+++ b/apps/site/src/components/ui/select.tsx
@@ -1,0 +1,205 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-line bg-transparent flex w-fit items-center justify-between gap-1.5 rounded-lg border px-3 py-1.5 text-xs tracking-wide lowercase whitespace-nowrap transition-colors outline-none select-none",
+        "focus-visible:border-ink focus-visible:ring-2 focus-visible:ring-ink/20",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "*:data-[slot=select-value]:line-clamp-1",
+        "*:data-[slot=select-value]:flex",
+        "*:data-[slot=select-value]:items-center",
+        "*:data-[slot=select-value]:gap-1.5",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="text-muted pointer-events-none size-3" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-raised text-ink border-line relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-hidden rounded-xl border shadow-lg",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+          "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-1.5 py-1 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "text-ink relative flex w-full cursor-default items-center gap-1.5 rounded-lg py-1.5 pr-7 pl-2.5 text-xs tracking-wide lowercase outline-none select-none",
+        "hover:bg-line/50 focus:bg-line/50",
+        "data-disabled:pointer-events-none data-disabled:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-3 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none size-3" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/site/src/editor/snippet.ts
+++ b/apps/site/src/editor/snippet.ts
@@ -12,7 +12,7 @@
 import type { TraitOverrides } from "blobatar";
 import { KEY_ORDER } from "./axes";
 
-export type Api = "react" | "string" | "http";
+export type Api = "http" | "react" | "vue" | "svelte" | "solid" | "preact" | "string";
 export type Motion = false | "hover" | "always";
 
 export interface SnippetInput {
@@ -85,11 +85,23 @@ export function snippet({ api, name, pinned, motion }: SnippetInput): string {
   const traits = entries(pinned);
   const seed = name || "blobatar";
 
-  return api === "react"
-    ? react(seed, traits, motion)
-    : api === "string"
-      ? string(seed, traits, motion)
-      : http(seed, traits, motion);
+  switch (api) {
+    case "http":
+      return http(seed, traits, motion);
+    case "react":
+      return react(seed, traits, motion);
+    case "vue":
+      return vue(seed, traits, motion);
+    case "svelte":
+      return svelte(seed, traits, motion);
+    case "solid":
+      return solid(seed, traits, motion);
+    case "preact":
+      return preact(seed, traits, motion);
+    case "string":
+    default:
+      return string(seed, traits, motion);
+  }
 }
 
 function react(
@@ -124,6 +136,142 @@ function react(
 
   if (motion) lines.push(`  animate="${motion}"`);
   lines.push(`/>;`);
+
+  return lines.join("\n");
+}
+
+function vue(
+  seed: string,
+  traits: (readonly [string, number | number[]])[],
+  motion: Motion,
+) {
+  const lines = [`<script setup>`, `import Blobatar from "blobatar/vue";`, `</script>`, ""];
+
+  if (motion)
+    lines.push(`<!-- animate renders inline SVG, not one <img> -->`);
+
+  if (traits.length) lines.push(nameNote);
+
+  lines.push(`<template>`);
+  lines.push(`  <Blobatar`);
+
+  if (traits.length === 1) {
+    const [k, v] = traits[0]!;
+    lines.push(`    name="${seed}"`);
+    lines.push(`    :traits="{ ${key(k)}: ${v} }"`);
+  } else if (traits.length) {
+    lines.push(`    name="${seed}"`);
+    lines.push(`    :traits="{`);
+    for (const [k, v] of traits) lines.push(`      ${key(k)}: ${v},`);
+    lines.push(`    }"`);
+  } else {
+    lines.push(`    name="${seed}"`);
+  }
+
+  if (motion) lines.push(`    animate="${motion}"`);
+  lines.push(`  />`);
+  lines.push(`</template>`);
+
+  return lines.join("\n");
+}
+
+function svelte(
+  seed: string,
+  traits: (readonly [string, number | number[]])[],
+  motion: Motion,
+) {
+  const lines = [`<script>`, `  import Blobatar from "blobatar/svelte";`, `</script>`, ""];
+
+  if (motion)
+    lines.push(`<!-- animate renders inline SVG, not one <img> -->`);
+
+  if (traits.length) lines.push(`<!-- ${nameNote} -->`);
+
+  if (traits.length === 1) {
+    const [k, v] = traits[0]!;
+    lines.push(`<Blobatar name="${seed}" traits={{ ${key(k)}: ${v} }}${motion ? ` animate="${motion}"` : ""} />`);
+  } else if (traits.length) {
+    lines.push(`<Blobatar`);
+    lines.push(`  name="${seed}"`);
+    lines.push(`  traits={{`);
+    for (const [k, v] of traits) lines.push(`    ${key(k)}: ${v},`);
+    lines.push(`  }}${motion ? `\n  animate="${motion}"` : ""}`);
+    lines.push(`/>`);
+  } else {
+    lines.push(`<Blobatar name="${seed}"${motion ? ` animate="${motion}"` : ""} />`);
+  }
+
+  return lines.join("\n");
+}
+
+function solid(
+  seed: string,
+  traits: (readonly [string, number | number[]])[],
+  motion: Motion,
+) {
+  const lines = [`import { Blobatar } from "blobatar/solid";`];
+
+  if (motion)
+    lines.push(
+      `import "blobatar/motion.css"; // animate renders inline SVG, not one <img>`,
+    );
+
+  lines.push("");
+  if (traits.length) lines.push(nameNote);
+
+  lines.push(`<Blobatar`);
+
+  if (traits.length === 1) {
+    const [k, v] = traits[0]!;
+    lines.push(`  name="${seed}"`);
+    lines.push(`  traits={{ ${key(k)}: ${v} }}`);
+  } else if (traits.length) {
+    lines.push(`  name="${seed}"`);
+    lines.push(`  traits={{`);
+    for (const [k, v] of traits) lines.push(`    ${key(k)}: ${v},`);
+    lines.push(`  }}`);
+  } else {
+    lines.push(`  name="${seed}"`);
+  }
+
+  if (motion) lines.push(`  animate="${motion}"`);
+  lines.push(`/>`);
+
+  return lines.join("\n");
+}
+
+function preact(
+  seed: string,
+  traits: (readonly [string, number | number[]])[],
+  motion: Motion,
+) {
+  const lines = [`import { Blobatar } from "blobatar/preact";`];
+
+  if (motion)
+    lines.push(
+      `import "blobatar/motion.css"; // animate renders inline SVG, not one <img>`,
+    );
+
+  lines.push("");
+  if (traits.length) lines.push(nameNote);
+
+  lines.push(`<Blobatar`);
+
+  if (traits.length === 1) {
+    const [k, v] = traits[0]!;
+    lines.push(`  name="${seed}"`);
+    lines.push(`  traits={{ ${key(k)}: ${v} }}`);
+  } else if (traits.length) {
+    lines.push(`  name="${seed}"`);
+    lines.push(`  traits={{`);
+    for (const [k, v] of traits) lines.push(`    ${key(k)}: ${v},`);
+    lines.push(`  }}`);
+  } else {
+    lines.push(`  name="${seed}"`);
+  }
+
+  if (motion) lines.push(`  animate="${motion}"`);
+  lines.push(`/>`);
 
   return lines.join("\n");
 }

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -10,6 +10,10 @@
       "blobatar/uri": ["../../packages/blobatar/src/uri.ts"],
       "blobatar/expression": ["../../packages/blobatar/src/expression.ts"],
       "blobatar/react": ["../../packages/blobatar/src/react.tsx"],
+      "blobatar/vue": ["../../packages/blobatar/src/vue.ts"],
+      "blobatar/svelte": ["../../packages/blobatar/src/svelte/index.ts"],
+      "blobatar/solid": ["../../packages/blobatar/src/solid/index.ts"],
+      "blobatar/preact": ["../../packages/blobatar/src/preact/index.ts"],
       "blobatar/motion.css": ["../../packages/blobatar/src/motion.css"]
     }
   },

--- a/bun.lock
+++ b/bun.lock
@@ -36,12 +36,14 @@
       "name": "site",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.23",
+        "@radix-ui/react-select": "^2.3.7",
         "@radix-ui/react-slider": "^1.4.7",
         "@radix-ui/react-toggle-group": "^1.1.2",
         "blobatar": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "geist": "^1.3.1",
+        "lucide-react": "^1.33.0",
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^3.0.1",
@@ -76,16 +78,22 @@
         "@types/bun": "latest",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "preact": "^10.29.8",
         "react": "^19",
         "react-dom": "^19",
+        "solid-js": "^1.9.15",
         "vue": "^3.5.0",
       },
       "peerDependencies": {
+        "preact": ">=10",
         "react": ">=18",
+        "solid-js": ">=1",
         "vue": ">=3",
       },
       "optionalPeers": [
+        "preact",
         "react",
+        "solid-js",
         "vue",
       ],
     },
@@ -381,6 +389,8 @@
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ=="],
 
+    "@radix-ui/react-select": ["@radix-ui/react-select@2.3.7", "", { "dependencies": { "@radix-ui/number": "1.1.3", "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-previous": "1.1.4", "@radix-ui/react-visually-hidden": "1.2.11", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg=="],
+
     "@radix-ui/react-slider": ["@radix-ui/react-slider@1.4.7", "", { "dependencies": { "@radix-ui/number": "1.1.3", "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-previous": "1.1.4", "@radix-ui/react-use-size": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
@@ -404,6 +414,8 @@
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.4", "", { "dependencies": { "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.11", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.3", "", {}, "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="],
 
@@ -805,6 +817,8 @@
 
     "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
+    "lucide-react": ["lucide-react@1.33.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg=="],
+
     "magic-string": ["magic-string@0.30.21", "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mediabunny": ["mediabunny@1.50.8", "", { "dependencies": { "@types/dom-mediacapture-transform": "^0.1.11", "@types/dom-webcodecs": "0.1.13" } }, "sha512-LgykLyQzhdpo0V2yw3UXmOpj+b4JAGdpHBwsPE6kjSt8Za0d1VllD+FV7EGHBcdV4+oHUAo+yrqbVAWxNSDCPQ=="],
@@ -869,6 +883,8 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
+
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -899,6 +915,10 @@
 
     "semver": ["semver@7.5.3", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ=="],
 
+    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
+
     "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -912,6 +932,8 @@
     "site": ["site@workspace:apps/site"],
 
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
+
+    "solid-js": ["solid-js@1.9.15", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg=="],
 
     "source-map": ["source-map@0.8.0", "", {}, "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ=="],
 

--- a/packages/blobatar/package.json
+++ b/packages/blobatar/package.json
@@ -16,6 +16,19 @@
     "./expression": { "types": "./dist/expression.d.ts", "default": "./dist/expression.js" },
     "./react": { "types": "./dist/react.d.ts", "default": "./dist/react.js" },
     "./vue": { "types": "./dist/vue.d.ts", "default": "./dist/vue.js" },
+    "./svelte": {
+      "types": "./src/svelte/index.ts",
+      "svelte": "./src/svelte/index.ts",
+      "default": "./src/svelte/index.ts"
+    },
+    "./solid": {
+      "types": "./src/solid/index.ts",
+      "default": "./src/solid/index.ts"
+    },
+    "./preact": {
+      "types": "./src/preact/index.ts",
+      "default": "./src/preact/index.ts"
+    },
     "./motion.css": "./dist/motion.css",
     "./package.json": "./package.json"
   },
@@ -37,18 +50,24 @@
   },
   "peerDependencies": {
     "react": ">=18",
-    "vue": ">=3"
+    "vue": ">=3",
+    "preact": ">=10",
+    "solid-js": ">=1"
   },
   "peerDependenciesMeta": {
     "react": { "optional": true },
-    "vue": { "optional": true }
+    "vue": { "optional": true },
+    "preact": { "optional": true },
+    "solid-js": { "optional": true }
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "preact": "^10.29.8",
     "react": "^19",
     "react-dom": "^19",
+    "solid-js": "^1.9.15",
     "vue": "^3.5.0"
   },
   "keywords": ["blobatar", "avatar", "identicon", "svg", "deterministic", "no-dependencies"],

--- a/packages/blobatar/scripts/build.ts
+++ b/packages/blobatar/scripts/build.ts
@@ -61,9 +61,14 @@ const build = await Bun.build({
   format: "esm",
   minify: true,
   sourcemap: "linked",
-  // React and Vue are peer dependencies and optional ones: never inline them,
+  // Frameworks are peer dependencies and optional ones: never inline them,
   // and never let the JSX runtime import get rewritten into the bundle either.
-  external: ["react", "react/jsx-runtime", "react/jsx-dev-runtime", "vue"],
+  external: [
+    "react", "react/jsx-runtime", "react/jsx-dev-runtime",
+    "vue",
+    "preact", "preact/compat",
+    "solid-js",
+  ],
   // What selects the JSX runtime. Bun reads `process.env.NODE_ENV` to choose
   // between `jsx` and `jsxDEV`, and a publish build run from a normal shell has
   // it unset — so without this the package shipped `react/jsx-dev-runtime`

--- a/packages/blobatar/src/preact/Blobatar.ts
+++ b/packages/blobatar/src/preact/Blobatar.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "preact/hooks";
+import { _parts } from "../blobatar";
+import { blobatarUri } from "../uri";
+import type { BlobatarProps } from "./types";
+
+export function Blobatar({
+  name: seed,
+  size,
+  generation,
+  background,
+  palette,
+  hue,
+  tone,
+  normalize,
+  contrast,
+  title,
+  animate,
+  expression,
+  traits,
+  ...rest
+}: BlobatarProps) {
+  const opts = { generation, background, palette, hue, tone, normalize, contrast, title, expression, traits };
+
+  const dep = JSON.stringify([seed, opts, animate]);
+
+  const src = useMemo(
+    () => (animate ? "" : blobatarUri(seed, opts)),
+    [dep],
+  );
+
+  const parts = useMemo(
+    () => (animate ? _parts(seed, { ...opts, animate }) : null),
+    [dep],
+  );
+
+  if (parts) {
+    const { style, ...svgRest } = rest as Record<string, unknown>;
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    svg.setAttribute("viewBox", "0 0 100 100");
+    if (size) {
+      svg.setAttribute("width", String(size));
+      svg.setAttribute("height", String(size));
+    }
+    if (title) {
+      svg.setAttribute("role", "img");
+      const titleEl = document.createElementNS("http://www.w3.org/2000/svg", "title");
+      titleEl.textContent = title;
+      svg.appendChild(titleEl);
+    } else {
+      svg.setAttribute("aria-hidden", "true");
+    }
+    const mergedStyle = { ...(parts.vars as Record<string, string>), ...(style as Record<string, string>) };
+    Object.entries(mergedStyle).forEach(([k, v]) => svg.style.setProperty(k, String(v)));
+    for (const [k, v] of Object.entries(svgRest)) {
+      if (v !== undefined && v !== null) {
+        svg.setAttribute(k, String(v));
+      }
+    }
+    if (parts.bg) {
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("d", parts.bg.d);
+      path.setAttribute("fill", parts.bg.fill);
+      svg.appendChild(path);
+    }
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    if (parts.cls) g.setAttribute("class", parts.cls);
+    g.innerHTML = parts.inner;
+    svg.appendChild(g);
+    return svg;
+  }
+
+  const { alt, ...imgRest } = rest as Record<string, unknown>;
+  const img = document.createElement("img");
+  img.src = src;
+  if (size) {
+    img.width = size;
+    img.height = size;
+  }
+  img.alt = (alt as string) ?? title ?? "";
+  for (const [k, v] of Object.entries(imgRest)) {
+    if (v !== undefined && v !== null) {
+      if (k === "class") {
+        img.className = String(v);
+      } else if (k === "style" && typeof v === "object") {
+        Object.entries(v as Record<string, string>).forEach(([sk, sv]) =>
+          img.style.setProperty(sk, String(sv)),
+        );
+      } else {
+        img.setAttribute(k, String(v));
+      }
+    }
+  }
+  return img;
+}

--- a/packages/blobatar/src/preact/index.ts
+++ b/packages/blobatar/src/preact/index.ts
@@ -1,0 +1,2 @@
+export { Blobatar } from "./Blobatar";
+export type { BlobatarProps } from "./types";

--- a/packages/blobatar/src/preact/types.ts
+++ b/packages/blobatar/src/preact/types.ts
@@ -1,0 +1,16 @@
+import type { Animate } from "../animate";
+import type { BlobatarOptions } from "../blobatar";
+
+type StaticProps = { animate?: false } & Record<string, unknown>;
+
+type AnimatedProps = { animate: Animate } & Record<string, unknown>;
+
+export type BlobatarProps = {
+  /**
+   * Who the blobatar is for. A username, a display name, an email, a bot's
+   * handle, a user id — any string, and the same string always renders the
+   * same blobatar. The only required prop.
+   */
+  name: string;
+} & BlobatarOptions &
+  (StaticProps | AnimatedProps);

--- a/packages/blobatar/src/solid/Blobatar.ts
+++ b/packages/blobatar/src/solid/Blobatar.ts
@@ -1,0 +1,93 @@
+import { createMemo } from "solid-js";
+import { _parts, type BlobatarOptions } from "../blobatar";
+import { blobatarUri } from "../uri";
+import type { BlobatarProps } from "./types";
+
+export function Blobatar(props: BlobatarProps) {
+  const opts = createMemo<BlobatarOptions>(() => ({
+    generation: props.generation,
+    background: props.background,
+    palette: props.palette,
+    hue: props.hue,
+    tone: props.tone,
+    normalize: props.normalize,
+    contrast: props.contrast,
+    title: props.title,
+    expression: props.expression,
+    traits: props.traits,
+  }));
+
+  const isAnimated = createMemo(() => !!props.animate);
+
+  const src = createMemo(() =>
+    isAnimated() ? "" : blobatarUri(props.name, opts()),
+  );
+
+  const parts = createMemo(() =>
+    isAnimated()
+      ? _parts(props.name, { ...opts(), animate: props.animate })
+      : null,
+  );
+
+  return () => {
+    const p = parts();
+    if (p) {
+      const { style, class: className, alt: _alt, ...svgRest } = props as Record<string, unknown>;
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+      svg.setAttribute("viewBox", "0 0 100 100");
+      if (props.size) {
+        svg.setAttribute("width", String(props.size));
+        svg.setAttribute("height", String(props.size));
+      }
+      if (props.title) {
+        svg.setAttribute("role", "img");
+        const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
+        title.textContent = props.title;
+        svg.appendChild(title);
+      } else {
+        svg.setAttribute("aria-hidden", "true");
+      }
+      const mergedStyle = { ...(p.vars as Record<string, string>), ...(style as Record<string, string>) };
+      Object.entries(mergedStyle).forEach(([k, v]) => svg.style.setProperty(k, String(v)));
+      if (className) {
+        svg.setAttribute("class", String(className));
+      }
+      for (const [k, v] of Object.entries(svgRest)) {
+        if (v !== undefined && v !== null) {
+          svg.setAttribute(k, String(v));
+        }
+      }
+      if (p.bg) {
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute("d", p.bg.d);
+        path.setAttribute("fill", p.bg.fill);
+        svg.appendChild(path);
+      }
+      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      if (p.cls) g.setAttribute("class", p.cls);
+      g.innerHTML = p.inner;
+      svg.appendChild(g);
+      return svg;
+    }
+
+    const { style, class: className, alt, ...imgRest } = props as Record<string, unknown>;
+    const img = document.createElement("img");
+    img.src = src();
+    if (props.size) {
+      img.width = props.size;
+      img.height = props.size;
+    }
+    img.alt = (alt as string) ?? props.title ?? "";
+    if (className) img.className = String(className);
+    if (style && typeof style === "object") {
+      Object.entries(style as Record<string, string>).forEach(([k, v]) => img.style.setProperty(k, String(v)));
+    }
+    for (const [k, v] of Object.entries(imgRest)) {
+      if (v !== undefined && v !== null) {
+        img.setAttribute(k, String(v));
+      }
+    }
+    return img;
+  };
+}

--- a/packages/blobatar/src/solid/index.ts
+++ b/packages/blobatar/src/solid/index.ts
@@ -1,0 +1,2 @@
+export { Blobatar } from "./Blobatar";
+export type { BlobatarProps } from "./types";

--- a/packages/blobatar/src/solid/types.ts
+++ b/packages/blobatar/src/solid/types.ts
@@ -1,0 +1,16 @@
+import type { Animate } from "../animate";
+import type { BlobatarOptions } from "../blobatar";
+
+type StaticProps = { animate?: false } & Record<string, unknown>;
+
+type AnimatedProps = { animate: Animate } & Record<string, unknown>;
+
+export type BlobatarProps = {
+  /**
+   * Who the blobatar is for. A username, a display name, an email, a bot's
+   * handle, a user id — any string, and the same string always renders the
+   * same blobatar. The only required prop.
+   */
+  name: string;
+} & BlobatarOptions &
+  (StaticProps | AnimatedProps);

--- a/packages/blobatar/src/svelte.d.ts
+++ b/packages/blobatar/src/svelte.d.ts
@@ -1,0 +1,5 @@
+declare module "*.svelte" {
+  import type { ComponentType, SvelteComponent } from "svelte";
+  const component: ComponentType<SvelteComponent>;
+  export default component;
+}

--- a/packages/blobatar/src/svelte/Blobatar.svelte
+++ b/packages/blobatar/src/svelte/Blobatar.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { _parts } from "../blobatar";
+  import { blobatarUri } from "../uri";
+  import type { BlobatarProps } from "./types";
+
+  let {
+    name: seed,
+    size,
+    background,
+    palette,
+    hue,
+    tone,
+    normalize,
+    contrast,
+    title,
+    animate,
+    expression,
+    traits,
+    class: className,
+    style: styleAttr,
+    ...rest
+  }: BlobatarProps = $props();
+
+  let opts = $derived({
+    size,
+    background,
+    palette,
+    hue,
+    tone,
+    normalize,
+    contrast,
+    title,
+    expression,
+    traits,
+  });
+
+  let isAnimated = $derived(!!animate);
+
+  let src = $derived(isAnimated ? "" : blobatarUri(seed, opts));
+
+  let parts = $derived(
+    isAnimated
+      ? _parts(seed, { ...opts, animate: animate === "always" ? "always" : "hover" })
+      : null,
+  );
+
+  let html = $derived(parts?.inner ?? "");
+</script>
+
+{#if parts}
+  {@const vars = parts.vars ?? {}}
+  {@const styleStr = styleAttr
+    ? Object.entries(vars).map(([k, v]) => `${k}:${v}`).join(";") + ";" + styleAttr
+    : Object.entries(vars).map(([k, v]) => `${k}:${v}`).join(";")}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 100 100"
+    width={size}
+    height={size}
+    role={title ? "img" : undefined}
+    aria-hidden={title ? undefined : true}
+    class={className}
+    style={styleStr}
+    {...rest}
+  >
+    {#if title}
+      <title>{title}</title>
+    {/if}
+    {#if parts.bg}
+      <path d={parts.bg.d} fill={parts.bg.fill} />
+    {/if}
+    <g class={parts.cls}>
+      {@html html}
+    </g>
+  </svg>
+{:else}
+  {@const alt = rest.alt ?? title ?? ""}
+  {@const { alt: _, ...imgRest } = rest}
+  <img
+    {src}
+    width={size}
+    height={size}
+    {alt}
+    class={className}
+    style={styleAttr}
+    {...imgRest}
+  />
+{/if}

--- a/packages/blobatar/src/svelte/index.ts
+++ b/packages/blobatar/src/svelte/index.ts
@@ -1,0 +1,2 @@
+export { default as Blobatar } from "./Blobatar.svelte";
+export type { BlobatarProps } from "./types";

--- a/packages/blobatar/src/svelte/types.ts
+++ b/packages/blobatar/src/svelte/types.ts
@@ -1,0 +1,18 @@
+import type { Animate } from "../animate";
+import type { BlobatarOptions } from "../blobatar";
+
+type StaticProps = { animate?: false };
+
+type AnimatedProps = { animate: Animate };
+
+export type BlobatarProps = {
+  /**
+   * Who the blobatar is for. A username, a display name, an email, a bot's
+   * handle, a user id — any string, and the same string always renders the
+   * same blobatar. The only required prop.
+   */
+  name: string;
+  class?: string;
+  style?: string;
+} & BlobatarOptions &
+  (StaticProps | AnimatedProps);


### PR DESCRIPTION
## Summary

Adds multi-framework support with source-resolved adapters for Svelte, Solid, and Preact. Each adapter follows the same structure as the existing React and Vue adapters.

## Changes

### New Framework Adapters
- **Svelte**: `src/svelte/` - Uses Svelte 5 runes (`$props`, `$derived`)
- **Solid**: `src/solid/` - Uses SolidJS primitives (`createMemo`)
- **Preact**: `src/preact/` - Uses Preact hooks (`useMemo`)

Each adapter includes:
- `types.ts` - Type definitions with `BlobatarProps`
- `Blobatar.svelte/.ts` - Component implementation
- `index.ts` - Re-exports component and types

### Package Configuration
- Updated `exports` map in `package.json` for new frameworks
- Added optional peer dependencies: `vue>=3`, `preact>=10`, `solid-js>=1`
- Added `svelte.d.ts` for TypeScript module declaration
- Updated `tsconfig.json` paths for site development

### Build Script
- Added `preact`, `preact/compat`, `solid-js` to externals

### Editor Updates
- Added snippet generation for all framework APIs (Svelte, Solid, Preact)
- Replaced responsive API selector with Radix UI Select component

## Technical Details

- Solid and Preact adapters use direct DOM API (`document.createElement`/`createElementNS`) because Bun bundler does not handle their JSX transforms
- Svelte adapter is source-resolved (requires consumer Svelte compiler)
- All adapters support both static (image URL) and animated (SVG generation) modes

## Testing
- All 154 existing tests pass
- Site builds successfully
- Typecheck passes (excluding pre-existing workspace type mismatches)