### PR TITLE
feat: publish the adapters as @blobatar/react and @blobatar/vue

### DIFF
--- a/.changeset/adapter-packages.md
+++ b/.changeset/adapter-packages.md
@@ -1,0 +1,20 @@
+---
+"blobatar": minor
+"@blobatar/react": minor
+"@blobatar/vue": minor
+---
+
+Adapters are published under their own names: **`@blobatar/react`** and **`@blobatar/vue`**.
+
+Nothing breaks. `blobatar/react` and `blobatar/vue` keep working and render exactly what they always did — the new packages re-export them, so they are the same component and cannot drift. Move when it suits you:
+
+```sh
+bunx blobatar-codemod .
+bun add @blobatar/react
+```
+
+The old subpaths are deprecated and frozen, and go in v3. They are also the last two: adapters added from here on are packages only, so `blobatar`'s optional peer list stops growing at `react` and `vue` instead of naming every framework the library ever supports.
+
+Also new: `blobatar/internal` (`_parts`, `_layout`, `serializeVars`), the entry point adapters build against. Its shape changes only on a major, together with every `@blobatar/*` package. It is not a general-purpose API — `blobatar()` and `blobatarUri()` remain the public answers for rendering markup.
+
+No blobatar changes. Faces are byte-identical to the previous release.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,12 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "blobatar",
+      "@blobatar/*"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Tests
         run: bunx turbo run test --filter=blobatar
 
+      # The cross-adapter equivalence check lives in its own private package
+      # because no single adapter can own it. It imports each adapter by
+      # package name, so this builds them and resolves through their real
+      # `exports` maps — the run that caught `@blobatar/react` shipping
+      # `export{a as Blobatar}` with no `a`.
+      - name: Adapter drift harness
+        run: bunx turbo run test --filter=@blobatar/harness
+
       - name: Size budgets
         run: bunx turbo run size --filter=blobatar
 
@@ -52,23 +60,29 @@ jobs:
           firefox --version
 
       - name: Composition gate
-        run: bunx turbo run probe --filter=blobatar
+        run: bunx turbo run probe --filter=@blobatar/harness
 
       - name: Build
-        run: bunx turbo run build --filter=blobatar
+        run: bunx turbo run build
 
       # Links the built package under Node, through its own `exports` map. This
       # is the step that catches a dist that is broken for everyone outside Bun.
       - name: Smoke the built package
         run: bunx turbo run smoke --filter=blobatar
 
+      # Every publishable package, not just core — a broken `files` or
+      # `exports` in an adapter should fail here rather than at publish.
       - name: Pack
-        run: npm pack --workspace blobatar --pack-destination /tmp
+        run: |
+          npm pack --workspace blobatar --pack-destination /tmp
+          npm pack --workspace @blobatar/react --pack-destination /tmp
+          npm pack --workspace @blobatar/vue --pack-destination /tmp
+          npm pack --workspace blobatar-codemod --pack-destination /tmp
 
       - uses: actions/upload-artifact@v4
         with:
           name: tarball
-          path: /tmp/blobatar-*.tgz
+          path: /tmp/*blobatar*.tgz
           retention-days: 7
 
   apps:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -135,8 +135,13 @@ dozen nodes. `animate` selects between them — the two cannot be combined,
 because `:hover` and host-page CSS cannot reach inside an `<img>`.
 
 **Adapter**:
-A framework integration that owns the outer element — `blobatar/react`,
-`blobatar/vue`. Owning the element is the whole of the distinction: an adapter
+A framework integration that owns the outer element, published as its own
+package — `@blobatar/react`, `@blobatar/vue`. The roster is open and every
+entry is a peer of every other. Two of them are *also* reachable as
+`blobatar/react` and `blobatar/vue`, which is a fact about what already shipped
+and not a tier: those subpaths are frozen and deprecated, no third is ever
+added, and in v3 there are none. Owning the element is the whole of the
+distinction: an adapter
 can hand back an `<img>` one moment and an inline `<svg>` the next, so it is
 the only thing that can honor `animate`. The string API returns markup it does
 not own and ignores it.
@@ -146,6 +151,11 @@ and the same options render the same blobatar, and an option a caller leaves
 out reaches the library left out. That is a rule rather than an observation:
 a framework that supplies its own default for an unset prop is an adapter
 inventing an answer the caller never gave.
+An adapter never carries a renderer. It reads `blobatar/internal` and peer-
+depends on the library, so two adapters on one page share one copy of the
+geometry rather than each bundling their own — and an adapter that inlined the
+library would silently stop tracking its version, which is the same failure as
+drift wearing different clothes.
 _Avoid_: wrapper, binding, integration. A _wrapper_ adds behavior on top; an
 adapter only changes the shape of what passes through. _Binding_ suggests
 something generated rather than written.
@@ -207,8 +217,21 @@ consumer and is not gated at all. A blobatar can be sad and still breathing.
 ### The repo
 
 **Package**:
-A workspace member under `packages/` — publishable. Currently just
-`blobatar` itself.
+A workspace member under `packages/` — publishable. `blobatar` is the renderer
+and carries no framework; each adapter is its own package beside it. Two
+members are publishable-shaped but are not: `harness` is private, and
+`codemod` is unscoped on purpose so the lockstep group cannot drag it along.
+
+**Lockstep**:
+That `blobatar` and every `@blobatar/*` package publish the same version,
+always. It is what keeps a major meaning one thing across a set of packages
+rather than one thing per package — an adapter re-expresses the library and
+adds nothing, so it has no semantics of its own to version, and its number is
+the library's number. Enforced twice, because neither half is sufficient:
+`fixed` keeps *published* versions in step, and an exact-major peer range
+refuses the *install* that npm would otherwise resolve happily.
+_Avoid_: synced, pinned. _Pinned_ is what the peer range does, which is the
+other half.
 
 **App**:
 A workspace member under `apps/` — never published, and always consumes

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ renders the same blobatar.
 
 ### React
 
+```sh
+bun add blobatar @blobatar/react
+```
+
 ```tsx
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 
 <Blobatar name={user.email} size={48} />;
 ```
@@ -29,9 +33,13 @@ element, so `className`, `alt` and the rest behave as you would expect.
 
 ### Vue
 
+```sh
+bun add blobatar @blobatar/vue
+```
+
 ```html
 <script setup>
-import { Blobatar } from "blobatar/vue";
+import { Blobatar } from "@blobatar/vue";
 </script>
 
 <template>
@@ -91,14 +99,25 @@ Both are opt-in. `animate` idles the blobatar — breathe, bob, blink, glance �
 and expressions are imported as values so you ship only the poses you use:
 
 ```tsx
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { happy } from "blobatar/expression";
 import "blobatar/motion.css"; // required — nothing animates without it
 
 <Blobatar name={user.email} animate="hover" expression={happy} size={64} />;
 ```
 
-The same props work with `blobatar/vue` — only the component import changes.
+The same props work with `@blobatar/vue` — only the component import changes.
+
+### Coming from `blobatar/react` or `blobatar/vue`
+
+Those subpaths still work and render exactly the same component — the packages
+above re-export them. They are deprecated and go in v3. Move whenever it suits
+you:
+
+```sh
+bunx blobatar-codemod .
+bun add @blobatar/react   # and/or @blobatar/vue
+```
 
 `animate` changes the rendering mode: a static blobatar is a single `<img>`, an
 animated one is inline SVG. Use `"hover"` in a grid and `"always"` for the

--- a/apps/demo/App.tsx
+++ b/apps/demo/App.tsx
@@ -23,7 +23,7 @@ import {
   wink,
   type Expression,
 } from "blobatar/expression";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { CANDIDATES } from "./candidates";
 
 /**

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -7,6 +7,7 @@
     "check": "true"
   },
   "dependencies": {
+    "@blobatar/react": "workspace:*",
     "blobatar": "workspace:*",
     "react": "^19",
     "react-dom": "^19"

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -11,6 +11,7 @@
       "blobatar/blob": ["../../packages/blobatar/src/blob.ts"],
       "blobatar/uri": ["../../packages/blobatar/src/uri.ts"],
       "blobatar/expression": ["../../packages/blobatar/src/expression.ts"],
+      "@blobatar/react": ["../../packages/react/src/index.tsx"],
       "blobatar/react": ["../../packages/blobatar/src/react.tsx"],
       "blobatar/motion.css": ["../../packages/blobatar/src/motion.css"]
     }

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -12,6 +12,7 @@
     "//scripts": "No `bun --filter blobatar build &&` prefixes any more, and no `bun run build &&` either. Both orderings are now `dependsOn` entries on the `preview` and `deploy` tasks in the root `turbo.json`, so the library build and this app's own build happen once, in order, whichever entry point is used."
   },
   "dependencies": {
+    "@blobatar/react": "workspace:*",
     "@radix-ui/react-popover": "^1.1.23",
     "@radix-ui/react-slider": "^1.4.7",
     "@radix-ui/react-toggle-group": "^1.1.2",

--- a/apps/site/src/Editor.tsx
+++ b/apps/site/src/Editor.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { traits as reader, type TraitOverrides } from "blobatar";
 import { Control } from "@/components/editor/control";
 import { ShapePicker, TonePicker } from "@/components/editor/pickers";

--- a/apps/site/src/components/Chat.tsx
+++ b/apps/site/src/components/Chat.tsx
@@ -1,4 +1,4 @@
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Facepile } from "@/components/ui/facepile";
 import { useNearViewport } from "@/lib/near-viewport";

--- a/apps/site/src/components/Hero.tsx
+++ b/apps/site/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import type { BlobatarOptions } from "blobatar";
 import {
   happy,
@@ -145,7 +145,7 @@ function snippet(
 ) {
   const posed = pose.value !== idle;
 
-  const imports = [`import { Blobatar } from "blobatar/react";`];
+  const imports = [`import { Blobatar } from "@blobatar/react";`];
   if (posed) imports.push(`import { ${pose.name} } from "blobatar/expression";`);
   imports.push(`import "blobatar/motion.css";`);
 

--- a/apps/site/src/components/Wall.tsx
+++ b/apps/site/src/components/Wall.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { NAMES, shuffled } from "@/names";
 import { useNearViewport } from "@/lib/near-viewport";
 

--- a/apps/site/src/components/editor/crowd.tsx
+++ b/apps/site/src/components/editor/crowd.tsx
@@ -1,4 +1,4 @@
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { type TraitOverrides } from "blobatar";
 import { NAMES } from "@/names";
 import { cn } from "@/lib/utils";

--- a/apps/site/src/components/editor/pickers.tsx
+++ b/apps/site/src/components/editor/pickers.tsx
@@ -1,4 +1,4 @@
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { palette, type TraitOverrides } from "blobatar";
 import { TONES, toggleShape, toggleTone } from "@/editor/axes";
 import { SHAPES } from "@/shapes";

--- a/apps/site/src/components/ui/facepile.tsx
+++ b/apps/site/src/components/ui/facepile.tsx
@@ -1,4 +1,4 @@
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { cn } from "@/lib/utils";
 
 /**

--- a/apps/site/src/components/ui/snippet.tsx
+++ b/apps/site/src/components/ui/snippet.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
  * the endpoint snippet renders as one long italic muted string.
  *
  * The property-name branch has to come *before* the general string one for the
- * same reason in miniature: `"eye.gap"` is a key and `"blobatar/react"` is a
+ * same reason in miniature: `"eye.gap"` is a key and `"@blobatar/react"` is a
  * string, and the only thing that separates them is the colon after. A single
  * string branch first would swallow both and there would be no second chance.
  */

--- a/apps/site/src/editor/snippet.test.ts
+++ b/apps/site/src/editor/snippet.test.ts
@@ -95,7 +95,7 @@ describe("what it emits", () => {
     const string = snip({ api: "string", name: NAME, pinned: {}, motion: false });
 
     expect(react).toContain(`name="${NAME}"`);
-    expect(react).toContain(`from "blobatar/react"`);
+    expect(react).toContain(`from "@blobatar/react"`);
     expect(string).toContain(`blobatar("${NAME}")`);
     expect(string).toContain(`from "blobatar"`);
   });
@@ -116,10 +116,10 @@ describe("what it emits", () => {
 
   test("the string API drops `animate` out loud rather than silently", () => {
     // `blobatar()` returns static markup whatever it is passed — animation is a
-    // `blobatar/react` option. Emitting it would be a snippet that lies.
+    // `@blobatar/react` option. Emitting it would be a snippet that lies.
     const code = snip({ api: "string", name: NAME, pinned: {}, motion: "always" });
     expect(code).not.toContain("animate:");
-    expect(code).toContain("// animate is a blobatar/react option");
+    expect(code).toContain("// animate is a @blobatar/react option");
   });
 
   test("the endpoint spelling is a url, with the generation pinned", () => {

--- a/apps/site/src/editor/snippet.ts
+++ b/apps/site/src/editor/snippet.ts
@@ -97,7 +97,7 @@ function react(
   traits: (readonly [string, number | number[]])[],
   motion: Motion,
 ) {
-  const lines = [`import { Blobatar } from "blobatar/react";`];
+  const lines = [`import { Blobatar } from "@blobatar/react";`];
   // The trade the library documents, stated where it is taken rather than in
   // prose beside the box: animating is what moves the blobatar out of a single
   // `<img>` and into a dozen inline SVG nodes.
@@ -136,12 +136,12 @@ function string(
   const lines = [`import { blobatar } from "blobatar";`];
   lines.push("");
 
-  // `animate` is honored by `blobatar/react` only — the string API returns
+  // `animate` is honored by `@blobatar/react` only — the string API returns
   // static markup whatever it is passed. Dropping it silently on the way over
   // would make this snippet a quieter blobatar than the one on screen, so it is
   // dropped out loud.
   if (motion)
-    lines.push(`// animate is a blobatar/react option — this renders static markup`);
+    lines.push(`// animate is a @blobatar/react option — this renders static markup`);
   if (traits.length) lines.push(nameNote);
 
   // Named `seed` here where the component takes `name`: same value, and the
@@ -233,7 +233,7 @@ function http(
     lines.push(`# no url spelling for ${unspellable.join(", ")} — from the name`);
   if (narrowed.length)
     lines.push(`# ${narrowed.join(", ")} narrowed — a url states one value, so this is from the name too`);
-  if (motion) lines.push(`# static svg — animate is a blobatar/react option`);
+  if (motion) lines.push(`# static svg — animate is a @blobatar/react option`);
 
   lines.push(`${ENDPOINT}${encodeURIComponent(seed)}?${query.join("&")}`);
   return lines.join("\n");

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -9,6 +9,7 @@
       "blobatar/blob": ["../../packages/blobatar/src/blob.ts"],
       "blobatar/uri": ["../../packages/blobatar/src/uri.ts"],
       "blobatar/expression": ["../../packages/blobatar/src/expression.ts"],
+      "@blobatar/react": ["../../packages/react/src/index.tsx"],
       "blobatar/react": ["../../packages/blobatar/src/react.tsx"],
       "blobatar/motion.css": ["../../packages/blobatar/src/motion.css"]
     }

--- a/apps/video/package.json
+++ b/apps/video/package.json
@@ -14,6 +14,8 @@
     "check": "bun scripts/check-crowd.ts && bun scripts/check-endpoint.ts && bun scripts/check-triangles.ts && bun scripts/check-adapters.ts"
   },
   "dependencies": {
+    "@blobatar/react": "workspace:*",
+    "@blobatar/vue": "workspace:*",
     "@remotion/cli": "^4.0.512",
     "blobatar": "workspace:*",
     "react": "^19",

--- a/apps/video/remotion.config.ts
+++ b/apps/video/remotion.config.ts
@@ -15,7 +15,7 @@ Config.setChromiumOpenGlRenderer("angle");
  * types, and this is what the bundler resolves at render time. Both lists have
  * to say the same thing.
  *
- * `$` on each key is exact-match: without it `blobatar/react` would resolve
+ * `$` on each key is exact-match: without it `@blobatar/react` would resolve
  * through the `blobatar` alias and land on a directory that does not exist.
  */
 Config.overrideWebpackConfig((current) => ({
@@ -28,8 +28,8 @@ Config.overrideWebpackConfig((current) => ({
       "blobatar/blob$": src("blob.ts"),
       "blobatar/uri$": src("uri.ts"),
       "blobatar/expression$": src("expression.ts"),
-      "blobatar/react$": src("react.tsx"),
-      "blobatar/vue$": src("vue.ts"),
+      "@blobatar/react$": src("react.tsx"),
+      "@blobatar/vue$": src("vue.ts"),
       "blobatar/animate$": src("animate.ts"),
       "blobatar/motion.css$": src("motion.css"),
     },

--- a/apps/video/scripts/check-adapters.ts
+++ b/apps/video/scripts/check-adapters.ts
@@ -1,8 +1,8 @@
 /**
  * The one number the adapters film puts on screen, and the claim under it.
  *
- * The film says two things a viewer cannot check: that `blobatar/vue` and
- * `blobatar/react` render the same blobatar, and that it is a specific number of
+ * The film says two things a viewer cannot check: that `@blobatar/vue` and
+ * `@blobatar/react` render the same blobatar, and that it is a specific number of
  * bytes. Both are measured here, against the real adapters, at exactly the props
  * the film renders — so a change to either adapter, or to the size or name on
  * screen, fails the build instead of shipping a film asserting a number that has
@@ -18,8 +18,8 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createSSRApp, h } from "vue";
 import { renderToString } from "vue/server-renderer";
-import { Blobatar as ReactBlobatar } from "../../../packages/blobatar/src/react";
-import { Blobatar as VueBlobatar } from "../../../packages/blobatar/src/vue";
+import { Blobatar as ReactBlobatar } from "@blobatar/react";
+import { Blobatar as VueBlobatar } from "@blobatar/vue";
 import { BYTES, NAME, SIZE } from "../src/swap";
 
 const props = { name: NAME, animate: "always" as const, size: SIZE };

--- a/apps/video/src/Adapters.tsx
+++ b/apps/video/src/Adapters.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
-import { Blobatar as ReactBlobatar } from "blobatar/react";
-import { Blobatar as VueBlobatar } from "blobatar/vue";
+import { Blobatar as ReactBlobatar } from "@blobatar/react";
+import { Blobatar as VueBlobatar } from "@blobatar/vue";
 import { Easing, interpolate, useCurrentFrame } from "remotion";
 import { MONO, SANS } from "./fonts";
 import { VueMount } from "./VueMount";
@@ -160,7 +160,7 @@ const Card: FC<{ frame: number }> = ({ frame }) => {
           color: TEXT,
         }}
       >
-        blobatar/vue
+        @blobatar/vue
       </div>
       <div style={{ fontFamily: MONO, fontSize: 25, color: MUTED }}>npm i blobatar</div>
     </div>

--- a/apps/video/src/Expressions.tsx
+++ b/apps/video/src/Expressions.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, FC } from "react";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { idle, type Expression } from "blobatar/expression";
 import { Easing, interpolate, useCurrentFrame } from "remotion";
 import { MONO, SANS } from "./fonts";

--- a/apps/video/src/Launch.tsx
+++ b/apps/video/src/Launch.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { Easing, interpolate, useCurrentFrame } from "remotion";
 import { MONO, SANS } from "./fonts";
 import { CROWD } from "./names";

--- a/apps/video/src/Triangles.tsx
+++ b/apps/video/src/Triangles.tsx
@@ -28,7 +28,7 @@
  */
 
 import type { FC } from "react";
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import { thinking } from "blobatar/expression";
 import { interpolate, spring, useCurrentFrame } from "remotion";
 import { CROWD } from "./names";

--- a/apps/video/src/VueMount.tsx
+++ b/apps/video/src/VueMount.tsx
@@ -2,11 +2,11 @@
  * A real Vue app, mounted inside a Remotion frame.
  *
  * This exists so the adapters film can be honest. Remotion is React, so the
- * cheap version of this film renders every frame with `blobatar/react` and
- * merely *writes* `blobatar/vue` in the code pane — a film that asserts parity
+ * cheap version of this film renders every frame with `@blobatar/react` and
+ * merely *writes* `@blobatar/vue` in the code pane — a film that asserts parity
  * while quietly demonstrating one adapter twice. The whole point is the other
  * thing: when the code says Vue, the creature on screen was rendered by
- * `blobatar/vue`, through Vue's own runtime, in that frame.
+ * `@blobatar/vue`, through Vue's own runtime, in that frame.
  *
  * It works because nothing about the motion layer is framework-shaped. The
  * idle loops are CSS on classes the adapter emits, and `seek.css` seeks them

--- a/apps/video/src/swap.ts
+++ b/apps/video/src/swap.ts
@@ -3,12 +3,12 @@
  *
  * The tweet makes one claim — *the Vue adapter is the React adapter* — and the
  * film has one moving part to match. A single import specifier is edited from
- * `blobatar/react` to `blobatar/vue`, and the blobatar above it does not change,
+ * `@blobatar/react` to `@blobatar/vue`, and the blobatar above it does not change,
  * because it cannot: the two adapters resolve to the same markup.
  *
  * What makes this a film rather than an assertion is that the creature is not a
  * picture of the claim, it *is* the claim. Remotion is React, so the cheap cut
- * renders `blobatar/react` throughout and merely writes the other name in the
+ * renders `@blobatar/react` throughout and merely writes the other name in the
  * code pane — parity asserted by a film demonstrating one adapter twice. This
  * one mounts a real Vue app (see `VueMount.tsx`) and hands the frame to it the
  * instant the specifier commits. Both are on screen the whole time, stacked and

--- a/apps/video/tsconfig.json
+++ b/apps/video/tsconfig.json
@@ -14,8 +14,11 @@
       "blobatar/blob": ["../../packages/blobatar/src/blob.ts"],
       "blobatar/uri": ["../../packages/blobatar/src/uri.ts"],
       "blobatar/expression": ["../../packages/blobatar/src/expression.ts"],
+      "@blobatar/react": ["../../packages/react/src/index.tsx"],
       "blobatar/react": ["../../packages/blobatar/src/react.tsx"],
+      "@blobatar/vue": ["../../packages/vue/src/index.ts"],
       "blobatar/vue": ["../../packages/blobatar/src/vue.ts"],
+      "blobatar/internal": ["../../packages/blobatar/src/internal.ts"],
       "blobatar/animate": ["../../packages/blobatar/src/animate.ts"],
       "blobatar/motion.css": ["../../packages/blobatar/src/motion.css"]
     }

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
     "apps/demo": {
       "name": "demo",
       "dependencies": {
+        "@blobatar/react": "workspace:*",
         "blobatar": "workspace:*",
         "react": "^19",
         "react-dom": "^19",
@@ -37,6 +38,7 @@
     "apps/site": {
       "name": "site",
       "dependencies": {
+        "@blobatar/react": "workspace:*",
         "@radix-ui/react-popover": "^1.1.23",
         "@radix-ui/react-slider": "^1.4.7",
         "@radix-ui/react-toggle-group": "^1.1.2",
@@ -59,6 +61,8 @@
     "apps/video": {
       "name": "video",
       "dependencies": {
+        "@blobatar/react": "workspace:*",
+        "@blobatar/vue": "workspace:*",
         "@remotion/cli": "^4.0.512",
         "blobatar": "workspace:*",
         "react": "^19",
@@ -90,6 +94,52 @@
         "react",
         "vue",
       ],
+    },
+    "packages/codemod": {
+      "name": "blobatar-codemod",
+      "version": "0.1.0",
+      "bin": {
+        "blobatar-codemod": "./dist/cli.js",
+      },
+    },
+    "packages/harness": {
+      "name": "@blobatar/harness",
+      "version": "2.1.0",
+      "devDependencies": {
+        "@blobatar/react": "workspace:*",
+        "@blobatar/vue": "workspace:*",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "blobatar": "workspace:*",
+        "react": "^19",
+        "react-dom": "^19",
+        "vue": "^3.5.0",
+      },
+    },
+    "packages/react": {
+      "name": "@blobatar/react",
+      "version": "2.1.0",
+      "devDependencies": {
+        "@types/react": "^19",
+        "blobatar": "workspace:*",
+        "react": "^19",
+      },
+      "peerDependencies": {
+        "blobatar": "2.x",
+        "react": ">=18",
+      },
+    },
+    "packages/vue": {
+      "name": "@blobatar/vue",
+      "version": "2.1.0",
+      "devDependencies": {
+        "blobatar": "workspace:*",
+        "vue": "^3.5.0",
+      },
+      "peerDependencies": {
+        "blobatar": "2.x",
+        "vue": ">=3",
+      },
     },
   },
   "packages": {
@@ -124,6 +174,12 @@
     "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
 
     "@babel/types": ["@babel/types@7.24.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.23.4", "@babel/helper-validator-identifier": "^7.22.20", "to-fast-properties": "^2.0.0" } }, "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w=="],
+
+    "@blobatar/harness": ["@blobatar/harness@workspace:packages/harness"],
+
+    "@blobatar/react": ["@blobatar/react@workspace:packages/react"],
+
+    "@blobatar/vue": ["@blobatar/vue@workspace:packages/vue"],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@8.0.0", "", { "dependencies": { "@changesets/config": "^4.0.0", "@changesets/format": "^0.1.1", "@changesets/git": "^4.0.0", "@changesets/should-skip-package": "^1.0.0", "@changesets/types": "^7.0.0", "import-meta-resolve": "^4.2.0", "jsonc-parser": "^3.3.1", "semver": "^7.8.1" } }, "sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w=="],
 
@@ -706,6 +762,8 @@
     "blobatar": ["blobatar@workspace:packages/blobatar"],
 
     "blobatar-api": ["blobatar-api@workspace:apps/api"],
+
+    "blobatar-codemod": ["blobatar-codemod@workspace:packages/codemod"],
 
     "blobatar-v1": ["blobatar@1.0.0", "", { "peerDependencies": { "react": ">=18" }, "optionalPeers": ["react"] }, "sha512-Xl122ZzoiW18Z5sLDHwcZXtHGCQwB1hN9LyUYEdjqBLJltk8h0Ap//1RWq612eABNLE957tii3aBP7hzeRXdsQ=="],
 

--- a/docs/adr/0009-adapters-as-their-own-packages.md
+++ b/docs/adr/0009-adapters-as-their-own-packages.md
@@ -1,0 +1,91 @@
+# Adapters are their own packages, added without a major
+
+Every framework adapter is now its own published package — `@blobatar/react`,
+`@blobatar/vue`, and the ones that follow — peer-depending on `blobatar` and
+sharing its version. `blobatar/react` and `blobatar/vue` remain, deprecated and
+frozen, so nothing installed today breaks. The change is **additive**, ships in
+a minor, and consumers move an import at a time.
+
+## Why not one package with more subpaths
+
+Two costs, and both grow with every framework added rather than staying put.
+
+A single `Bun.build` call cannot hold five mutually incompatible JSX transforms.
+Solid needs `babel-preset-solid`, Preact its own runtime, Svelte a compiler.
+This is not speculative: an earlier attempt to add three adapters as subpaths
+gave up on the transforms and hand-rolled `document.createElementNS` instead,
+shipping a Preact adapter that rendered an empty string.
+
+And every consumer of `blobatar` would see an optional-peer list naming every
+framework the library has ever supported, whether they use one or none.
+
+Splitting buys neither of those back in bytes — subpath exports already gave
+per-framework granularity, and nobody importing the React entry pulls Vue. It
+buys **build isolation** and **peer hygiene**, which is what was actually
+scarce.
+
+## Why not spend a major on it
+
+A clean break was built first: implementations moved out of core,
+`blobatar/react` deleted, core's peer list emptied, a codemod for the import
+rewrite. It works, and it was rejected on what it would cost a consumer.
+
+ADR-0008 makes the package major the generation selector, so a major is how
+somebody opts into every one of their users getting a different face. Spending
+one on a repackaging means **a consumer cannot take the new import paths without
+also taking a new generation.** Those are unrelated decisions and each should be
+separately refusable. Keeping the split additive is what keeps them separate,
+and it leaves ADR-0008 intact rather than amending the repo's most expensive
+record to buy a tidier package layout.
+
+The subpaths go in v3, alongside the generation that was going to require a
+major anyway. Until then a consumer migrates when it suits them, or not at all.
+
+## Consequences
+
+**Core's peer list is frozen at `react` and `vue`, and this is the rule that
+matters most.** No third subpath is ever added beside them. `@blobatar/svelte`,
+`@blobatar/solid` and `@blobatar/preact` have no `blobatar/svelte` counterpart
+and must not grow one — the moment they do, the peer list starts growing again
+and the reason for splitting is gone. The two that exist are a legacy artifact,
+not a pattern.
+
+That does leave two adapters reachable by two names for one major, and one tier
+of adapters that predates the split. The asymmetry is real and it is bounded:
+it belongs to what already shipped, never to what is added next.
+
+`@blobatar/react` and `@blobatar/vue` re-export core's subpaths rather than
+holding the components, and the direction is forced. Core cannot depend on a
+package that peer-depends on core, and shipping a second copy of a component
+from core would be two definitions drifting inside one release. So while
+`blobatar/react` exists, the component lives with it, and the new package is
+the alias. At v3 they trade places.
+
+`blobatar/internal` (`_parts`, `_layout`, `serializeVars`) exists for the
+adapters that are not aliases. Its shape changes only on a major together with
+every `@blobatar/*` package — truthful only because the set releases in
+lockstep, and useless as a general-purpose API, which its own header says.
+
+Lockstep is enforced from both ends because neither is sufficient. `fixed` in
+`.changeset/config.json` keeps published versions in step; it does nothing about
+installs, since npm resolves each package independently. So every adapter
+peer-depends on core with an **exact major range** (`2.x`, never `^2`), and
+`packages/harness` asserts that range against core's own version rather than
+trusting it — release tooling rewrites workspace ranges, and a caret would
+permit the mixed pair the range exists to forbid.
+
+The cross-adapter equivalence test moved to `packages/harness`, private and
+never published, and now imports adapters **by package name** so it resolves
+through their real `exports` maps and built `dist`. That earned itself
+immediately: the first build of `@blobatar/react` emitted `export{a as Blobatar}`
+with no `a` — the Bun re-export bug `VERSION` documents in `src/index.ts`, which
+turns out **not** to require `splitting: true` as that note claims.
+
+It also gained an assertion that agreement alone cannot give: that each adapter
+renders *something*. Two adapters that both render nothing agree perfectly,
+which is exactly how the abandoned subpath attempt passed a clean typecheck and
+a green suite.
+
+Adding a framework is now a package: its own build, its own peer, its own row in
+the harness. The last is not optional — a new adapter with no row is a hole the
+rest of the suite cannot see.

--- a/packages/blobatar/README.md
+++ b/packages/blobatar/README.md
@@ -8,15 +8,19 @@ import { blobatar } from "blobatar";
 blobatar("alain@example.com"); // => '<svg xmlns="..." viewBox="0 0 100 100">…'
 ```
 
+```sh
+bun add blobatar @blobatar/react
+```
+
 ```tsx
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 
 <Blobatar name={user.email} size={48} />;
 ```
 
 ```html
 <script setup>
-import { Blobatar } from "blobatar/vue";
+import { Blobatar } from "@blobatar/vue";
 </script>
 
 <template>
@@ -153,7 +157,7 @@ the occasional glance to one side. Every timing and direction is drawn from the
 name, so a grid reads as a crowd rather than a drill team.
 
 ```tsx
-import { Blobatar } from "blobatar/react";
+import { Blobatar } from "@blobatar/react";
 import "blobatar/motion.css"; // required — nothing animates without it
 
 <Blobatar name={user.email} animate="hover" size={48} />;
@@ -161,7 +165,7 @@ import "blobatar/motion.css"; // required — nothing animates without it
 
 ```html
 <script setup>
-import { Blobatar } from "blobatar/vue";
+import { Blobatar } from "@blobatar/vue";
 import "blobatar/motion.css"; // required — nothing animates without it
 </script>
 
@@ -189,7 +193,7 @@ pixel. It is worth the most on a profile header, which is what `"always"` is
 for. Eyes may cross outside the body outline on a hard glance; that is intended,
 and reads as a face turning rather than as a bug.
 
-Currently `blobatar/react` and `blobatar/vue` only. The string API still returns static markup:
+Currently `@blobatar/react` and `@blobatar/vue` only. The string API still returns static markup:
 supporting `animate` there means every consumer of `blobatar()` carries the motion
 code whether they animate or not, which is a real cost for a feature most
 callers will never use. If you need animated markup without either framework,
@@ -236,7 +240,7 @@ you hold, not an animation you fire. Without the stylesheet, or under
 a creature with its attention somewhere else. Whatever it is waiting on still
 needs to be announced somewhere real in your DOM — the face is decoration.
 
-The same values work with `blobatar/vue`; only the import of the component
+The same values work with `@blobatar/vue`; only the import of the component
 itself changes.
 
 The first expression you import costs about 340 bytes (the shared serializer and

--- a/packages/blobatar/package.json
+++ b/packages/blobatar/package.json
@@ -4,18 +4,49 @@
   "description": "Deterministic geometric blobatars from any string. No dependencies.",
   "type": "module",
   "//sideEffects": "Not `false`. That would license bundlers to drop `import \"blobatar/motion.css\"` as dead weight, and animated blobatars would silently render static for everyone shipping through a bundler.",
-  "sideEffects": ["*.css"],
-  "files": ["dist", "src", "README.md", "CHANGELOG.md", "LICENSE"],
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "//exports": "Built JS for everyone. What the workspace apps use in development is not this map — they alias `blobatar/*` back to `src` through tsconfig paths, so editing a curve shows up in the tuning grid on save. Keeping one resolution here means the published package resolves identically under every runtime and bundler.",
+  "//internal": "Adapters only. Its shape changes on a major together with every `@blobatar/*` package, which is a guarantee lockstep release makes truthful and nothing else would. See the header of `src/internal.ts`.",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
-    "./blob": { "types": "./dist/blob.d.ts", "default": "./dist/blob.js" },
-    "./uri": { "types": "./dist/uri.d.ts", "default": "./dist/uri.js" },
-    "./expression": { "types": "./dist/expression.d.ts", "default": "./dist/expression.js" },
-    "./react": { "types": "./dist/react.d.ts", "default": "./dist/react.js" },
-    "./vue": { "types": "./dist/vue.d.ts", "default": "./dist/vue.js" },
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./blob": {
+      "types": "./dist/blob.d.ts",
+      "default": "./dist/blob.js"
+    },
+    "./uri": {
+      "types": "./dist/uri.d.ts",
+      "default": "./dist/uri.js"
+    },
+    "./expression": {
+      "types": "./dist/expression.d.ts",
+      "default": "./dist/expression.js"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "default": "./dist/internal.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "default": "./dist/react.js"
+    },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "default": "./dist/vue.js"
+    },
     "./motion.css": "./dist/motion.css",
     "./package.json": "./package.json"
   },
@@ -25,23 +56,15 @@
   "scripts": {
     "test": "bun test",
     "size": "bun scripts/size.ts",
-    "probe": "bun scripts/probe-compose.ts",
     "build": "bun scripts/build.ts",
     "smoke": "node scripts/smoke.mjs",
     "//golden": "Regenerating is a deliberate act, so the script refuses without `--write` and says why. `check` does not call it — `bun test` already asserts against the fixture, which is the direction that matters.",
     "golden": "bun scripts/golden.ts",
     "//typecheck": "CI runs this first, so `check` does too. It is a named script rather than an inline `tsc` so the two cannot drift — a local gate that is a subset of CI is a gate that goes green on code CI rejects, which is exactly how a type error reached a pull request.",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "check": "bun run typecheck && bun test && bun run size && bun run probe && bun run build && bun run smoke",
-    "prepack": "bun run build"
-  },
-  "peerDependencies": {
-    "react": ">=18",
-    "vue": ">=3"
-  },
-  "peerDependenciesMeta": {
-    "react": { "optional": true },
-    "vue": { "optional": true }
+    "check": "bun run typecheck && bun test && bun run size && bun run probe && bun run smoke",
+    "prepack": "bun run build",
+    "probe": "bun scripts/probe-compose.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -51,7 +74,14 @@
     "react-dom": "^19",
     "vue": "^3.5.0"
   },
-  "keywords": ["blobatar", "avatar", "identicon", "svg", "deterministic", "no-dependencies"],
+  "keywords": [
+    "blobatar",
+    "avatar",
+    "identicon",
+    "svg",
+    "deterministic",
+    "no-dependencies"
+  ],
   "license": "MIT",
   "author": "Alain",
   "repository": {
@@ -60,5 +90,19 @@
     "directory": "packages/blobatar"
   },
   "homepage": "https://github.com/Alain00/blobatar#readme",
-  "bugs": "https://github.com/Alain00/blobatar/issues"
+  "bugs": "https://github.com/Alain00/blobatar/issues",
+  "//check": "No `bun run build` here. The build is a turbo task that `check` depends on, so it runs once for the whole workspace before any check reads a `dist` — a check that rebuilt its own package would delete `dist` out from under a concurrent check in another one.",
+  "//react-vue": "`./react` and `./vue` are **deprecated and frozen**. They are here because they shipped in v2 with consumers, and removing them is a v3 change; `@blobatar/react` and `@blobatar/vue` are where they live now, and `blobatar-codemod` moves an import across in one command. Both are removed in v3 — see the `@deprecated` banners in `src/react.tsx` and `src/vue.ts`, which is where an editor will surface it. Frozen means no third subpath is ever added beside them: `@blobatar/svelte`, `@blobatar/solid` and `@blobatar/preact` have no `blobatar/svelte` counterpart and must not grow one. These two are a legacy artifact, not a pattern — the peer list below is the reason, and it stops growing here.",
+  "peerDependencies": {
+    "react": ">=18",
+    "vue": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    }
+  }
 }

--- a/packages/blobatar/scripts/build.ts
+++ b/packages/blobatar/scripts/build.ts
@@ -48,6 +48,7 @@ const ENTRIES = [
   "src/blob.ts",
   "src/uri.ts",
   "src/expression.ts",
+  "src/internal.ts",
   "src/react.tsx",
   "src/vue.ts",
 ];

--- a/packages/blobatar/scripts/smoke.mjs
+++ b/packages/blobatar/scripts/smoke.mjs
@@ -23,6 +23,7 @@ import { blobatar, palette, traits, normalizeSeed } from "blobatar";
 import { blobatar as blob } from "blobatar/blob";
 import { blobatarUri } from "blobatar/uri";
 import * as poses from "blobatar/expression";
+import { _parts, _layout, serializeVars } from "blobatar/internal";
 import { Blobatar } from "blobatar/react";
 import { Blobatar as VueBlobatar } from "blobatar/vue";
 
@@ -64,6 +65,18 @@ check("blobatar/expression", () => {
     svg(blob("alain", { expression: pose }), `blob + ${name}`);
   }
   return `${named.length} poses — ${named.map(([n]) => n).join(", ")}`;
+});
+
+check("blobatar/internal", () => {
+  // The adapters' entry point, linked the way they link it. It is almost
+  // entirely re-exports, which is the exact module shape that produced the
+  // bundler bug this file exists to catch — so an unlinkable `internal` would
+  // break every `@blobatar/*` package at once while `bun test` stayed green.
+  const p = _parts("alain", { animate: "hover" });
+  assert(p.inner.length > 0, "internal _parts returned no markup");
+  assert(typeof serializeVars(p.vars ?? {}) === "string", "serializeVars did not return a string");
+  assert(typeof _layout("alain").palette === "object", "internal _layout returned no palette");
+  return `_parts ${p.inner.length} chars`;
 });
 
 check("blobatar/uri", () => {

--- a/packages/blobatar/src/blobatar.ts
+++ b/packages/blobatar/src/blobatar.ts
@@ -62,7 +62,7 @@ const motion = (mode: Animate, e?: Expression) => (t: Traits, p: Palette) => {
 /**
  * The `<svg>` contents and its motion custom properties, separately.
  *
- * For renderers that own the outer element themselves — `blobatar/react` when
+ * For renderers that own the outer element themselves — `@blobatar/react` when
  * animating. Underscored because the shape of this object is not public API.
  */
 export function _parts(name: string, opts: BlobatarOptions = {}) {

--- a/packages/blobatar/src/internal.ts
+++ b/packages/blobatar/src/internal.ts
@@ -1,0 +1,55 @@
+/**
+ * What an adapter needs and a consumer does not.
+ *
+ * `_parts` and `_layout` used to be reachable only as underscored exports of
+ * `blobatar.ts` — "underscored because the shape of this object is not public
+ * API". That claim held for exactly as long as every caller lived in this
+ * directory. The adapters are separate packages now, so the seam crosses a
+ * published boundary, and a documented-private object that is nonetheless
+ * load-bearing published surface is a convention that stops being one the first
+ * time somebody outside the repo finds it.
+ *
+ * So it is stated instead of implied.
+ *
+ * ## The contract
+ *
+ * **This entry point is for the `@blobatar/*` adapters.** Its shape changes
+ * only on a major, together with every adapter, and it carries no deprecation
+ * period of its own — a minor may add to it, never rename or remove.
+ *
+ * That rule is only truthful because the whole set is released in lockstep:
+ * `blobatar` and every `@blobatar/*` package publish the same version, always
+ * (see `.changeset/config.json`). A consumer who imports from here is opting
+ * into an interface whose stability guarantee is "the adapters were updated in
+ * the same commit" — which is a real guarantee, and a different one from what
+ * `blobatar`, `blobatar/blob` and `blobatar/uri` offer.
+ *
+ * Nothing here is needed to render a blobatar. If you are reaching for `_parts`
+ * to build markup, `blobatar()` and `blobatarUri()` are the public answers and
+ * they are not going to move under you.
+ */
+
+import { serializeVars as serialize } from "./animate";
+
+export { _layout, _parts } from "./blobatar";
+export type { Animate, BlobatarOptions, Expression } from "./blobatar";
+export type { Palette } from "./color";
+export type { TraitOverrides, Traits } from "./traits";
+
+/**
+ * Re-exported through a binding rather than `export { serializeVars }`, and the
+ * indirection is load-bearing for the same reason `VERSION` is in
+ * `src/index.ts`.
+ *
+ * On Bun 1.3.14, bundling an entry whose body is *nothing but* named re-exports
+ * against a package declaring `sideEffects` yields a module re-exporting names
+ * it never imported, and Node throws `SyntaxError: Export 'a' is not defined in
+ * module` on link. Everything else in this file is a re-export, so one real
+ * binding in the module body is what keeps the graph from being dropped.
+ *
+ * The shipping build does not split, which is what keeps this from mattering
+ * today — but `scripts/smoke.mjs` links this entry under Node on every build,
+ * and it is the line that keeps it linking if splitting is ever turned back on.
+ * Collapsing it into the re-export list above is not a tidy-up.
+ */
+export const serializeVars = serialize;

--- a/packages/blobatar/src/react.tsx
+++ b/packages/blobatar/src/react.tsx
@@ -1,3 +1,26 @@
+/**
+ * **Deprecated — moved to `@blobatar/react`.**
+ *
+ * This entry point still works and still renders exactly what it always did.
+ * It is frozen, not maintained in parallel: `@blobatar/react` re-exports this
+ * component, so the two are the same object and cannot drift.
+ *
+ * ```sh
+ * bunx blobatar-codemod .
+ * bun add @blobatar/react
+ * ```
+ *
+ * Removed in v3. Nothing else about the component changes when you move — same
+ * props, same output, only the specifier.
+ *
+ * The reason it is still here rather than deleted: removing it is breaking, and
+ * a break costs a major, and a major is how a consumer opts into their users'
+ * faces changing (ADR-0008). Spending one on a repackaging would force every
+ * consumer to take a new generation to get a new import path. So the two travel
+ * separately, and this subpath waits for the major that was going to happen
+ * anyway.
+ */
+
 import { useMemo, type ImgHTMLAttributes, type SVGProps } from "react";
 import type { Animate } from "./animate";
 import { _parts, type BlobatarOptions } from "./blobatar";

--- a/packages/blobatar/src/render.ts
+++ b/packages/blobatar/src/render.ts
@@ -51,10 +51,10 @@ export interface BlobatarOptions {
    *
    * Requires `import "blobatar/motion.css"`, and requires the blobatar to be
    * inline SVG — content inside an `<img>` is an isolated document that hover
-   * cannot reach. `blobatar/react` and `blobatar/vue` switch rendering mode
+   * cannot reach. `@blobatar/react` and `@blobatar/vue` switch rendering mode
    * for you; the string API is already inline.
    *
-   * **Honored by the framework adapters (`blobatar/react`, `blobatar/vue`)
+   * **Honored by the framework adapters (`@blobatar/react`, `@blobatar/vue`)
    * only.** `blobatar()` returns static markup regardless: a branch on
    * `animate` inside it keeps the motion module alive for every caller,
    * animating or not, which measured at ~190 B. An animated string API wants

--- a/packages/blobatar/src/vue.ts
+++ b/packages/blobatar/src/vue.ts
@@ -1,3 +1,26 @@
+/**
+ * **Deprecated — moved to `@blobatar/vue`.**
+ *
+ * This entry point still works and still renders exactly what it always did.
+ * It is frozen, not maintained in parallel: `@blobatar/vue` re-exports this
+ * component, so the two are the same object and cannot drift.
+ *
+ * ```sh
+ * bunx blobatar-codemod .
+ * bun add @blobatar/vue
+ * ```
+ *
+ * Removed in v3. Nothing else about the component changes when you move — same
+ * props, same output, only the specifier.
+ *
+ * The reason it is still here rather than deleted: removing it is breaking, and
+ * a break costs a major, and a major is how a consumer opts into their users'
+ * faces changing (ADR-0008). Spending one on a repackaging would force every
+ * consumer to take a new generation to get a new import path. So the two travel
+ * separately, and this subpath waits for the major that was going to happen
+ * anyway.
+ */
+
 import {
   computed,
   defineComponent,

--- a/packages/codemod/LICENSE
+++ b/packages/codemod/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Alain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -1,0 +1,52 @@
+# blobatar-codemod
+
+Migrates `blobatar/react` and `blobatar/vue` imports to the `@blobatar/react`
+and `@blobatar/vue` packages, which is the whole of the v2 → v3 change for
+adapter consumers.
+
+```sh
+bunx blobatar-codemod .            # rewrite in place
+bunx blobatar-codemod . --dry-run  # print what would change
+bunx blobatar-codemod src app      # or name the paths yourself
+```
+
+Then add the adapters you use. The codemod deliberately does not install
+anything or touch dependency versions — that is one command, in your own
+package manager, and a codemod that installs things is one you would be right
+to be wary of.
+
+```sh
+bun add @blobatar/react   # and/or @blobatar/vue
+```
+
+## What it touches
+
+Every `blobatar/react` and `blobatar/vue` specifier, in any form — `import`,
+`export … from`, `require`, dynamic `import()`, a `package.json` dependency
+key, or prose in a comment. A specifier rewrite has no reason to care which of
+those it is in, and trying to care is how a codemod misses the one form your
+codebase actually uses.
+
+It walks `.ts .tsx .js .jsx .mjs .mts .vue .svelte .astro .json .md .mdx .html`
+and skips `node_modules`, `dist`, `build`, `.next`, `.turbo`, `coverage`, `out`
+and dotfiles.
+
+## What it will not do
+
+- **Fire twice.** `@blobatar/react` contains the literal `blobatar/react`, and
+  the transform excludes it. Running on a migrated or half-migrated tree is a
+  no-op, which is the property that lets you re-run it without thinking.
+- **Touch a package that merely looks similar.** `not-blobatar/react`,
+  `myblobatar/react`, `vendor/blobatar/react` and `blobatar/reactive` are all
+  left alone.
+- **Touch core entry points.** `blobatar`, `blobatar/blob`, `blobatar/uri`,
+  `blobatar/expression`, `blobatar/internal` and `blobatar/motion.css` did not
+  move.
+
+## One caveat worth knowing
+
+It rewrites prose as well as code, which is right for your own docs and wrong
+for anything that is a historical record — a changelog, an ADR, a decision log.
+Those describe what was true when they were written. Give the tool the paths
+you want changed rather than the repository root if that distinction matters to
+you; it was written after doing exactly this to the blobatar repo's own ADRs.

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "blobatar-codemod",
+  "version": "0.1.0",
+  "description": "Rewrites @blobatar/react and @blobatar/vue imports to the @blobatar/* adapter packages.",
+  "type": "module",
+  "//name": "Unscoped, and deliberately not `@blobatar/codemod`. The `fixed` group in `.changeset/config.json` matches `@blobatar/*`, so a scoped name would be dragged to every library major — and a migration tool's version should track the migration it performs, not the generation of the renderer. It is also the one package here that a consumer runs rather than installs.",
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "bin": {
+    "blobatar-codemod": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun scripts/build.ts",
+    "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "bun run typecheck && bun test"
+  },
+  "keywords": [
+    "blobatar",
+    "codemod",
+    "migration"
+  ],
+  "license": "MIT",
+  "author": "Alain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/codemod"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues",
+  "//check": "No `bun run build` here. The build is a turbo task that `check` depends on, so it runs once for the whole workspace before any check reads a `dist` — a check that rebuilt its own package would delete `dist` out from under a concurrent check in another one."
+}

--- a/packages/codemod/scripts/build.ts
+++ b/packages/codemod/scripts/build.ts
@@ -1,0 +1,23 @@
+/** Publish build. Two entries: the transform, and the bin that walks a tree with it. */
+import { rmSync } from "node:fs";
+import { $ } from "bun";
+
+rmSync("dist", { recursive: true, force: true });
+
+const build = await Bun.build({
+  entrypoints: ["src/index.ts", "src/cli.ts"],
+  outdir: "dist",
+  target: "node",
+  format: "esm",
+  sourcemap: "linked",
+});
+
+if (!build.success) {
+  for (const log of build.logs) console.error(log);
+  process.exit(1);
+}
+
+await $`bunx tsc -p tsconfig.build.json`;
+for (const out of build.outputs) {
+  if (out.kind === "entry-point") console.log(`✓ ${out.path.replace(process.cwd() + "/", "")}`);
+}

--- a/packages/codemod/src/cli.ts
+++ b/packages/codemod/src/cli.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * `bunx blobatar-codemod [paths…]`
+ *
+ * Walks the given paths (the working directory by default), rewrites every
+ * `@blobatar/react` and `@blobatar/vue` specifier it finds, and prints what it
+ * touched. `--dry-run` prints without writing.
+ *
+ * It deliberately does **not** edit `package.json` dependency *versions* or run
+ * an install. Adding `@blobatar/react` to a project is one command the consumer
+ * should run themselves, in their own package manager — a codemod that installs
+ * things is a codemod people are right to be wary of.
+ */
+
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { MIGRATABLE, SKIP, transform } from "./index";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const roots = args.filter((a) => !a.startsWith("-"));
+if (roots.length === 0) roots.push(process.cwd());
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") && entry.name !== ".changeset") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP.has(entry.name)) continue;
+      yield* walk(full);
+    } else if (MIGRATABLE.test(entry.name)) {
+      yield full;
+    }
+  }
+}
+
+let files = 0;
+let rewrites = 0;
+
+for (const root of roots) {
+  const info = await stat(root).catch(() => null);
+  if (!info) {
+    console.error(`blobatar-codemod: no such path: ${root}`);
+    process.exitCode = 1;
+    continue;
+  }
+  const paths = info.isDirectory() ? walk(root) : (async function* () { yield root; })();
+
+  for await (const path of paths) {
+    const before = await readFile(path, "utf8");
+    const { code, changes } = transform(before);
+    if (changes.length === 0) continue;
+
+    files++;
+    rewrites += changes.length;
+    console.log(`${relative(process.cwd(), path) || path}`);
+    for (const c of changes) console.log(`  ${c.line}: ${c.from} → ${c.to}`);
+    if (!dryRun) await writeFile(path, code);
+  }
+}
+
+if (files === 0) {
+  console.log("Nothing to migrate — no `blobatar/react` or `blobatar/vue` specifiers found.");
+} else {
+  console.log(
+    `\n${dryRun ? "Would rewrite" : "Rewrote"} ${rewrites} specifier${rewrites === 1 ? "" : "s"} across ${files} file${files === 1 ? "" : "s"}.`,
+  );
+  if (!dryRun) {
+    console.log("\nNext, add the adapters you use — the codemod does not install for you:");
+    console.log("  bun add @blobatar/react   # and/or @blobatar/vue");
+  }
+}

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ * The v2 → v3 import migration, as a pure string transform.
+ *
+ * v3 removes `blobatar/react` and `blobatar/vue`; the components live in
+ * `@blobatar/react` and `@blobatar/vue`. Nothing else about them changed — same
+ * component, same props, same behaviour — so the whole migration is a specifier
+ * rewrite, which is exactly the kind of change a consumer should not have to
+ * make by hand across a codebase.
+ */
+
+/** The subpaths that moved, and where each went. */
+export const MOVES = {
+  react: "@blobatar/react",
+  vue: "@blobatar/vue",
+} as const;
+
+/**
+ * Matches `blobatar/react` and `blobatar/vue` anywhere — imports, `require`,
+ * dynamic `import()`, JSON dependency keys, prose in comments and docs.
+ *
+ * A specifier rewrite has no reason to care which of those it is in, and trying
+ * to care is how a codemod misses the one form a codebase actually uses.
+ *
+ * The lookbehind carries the whole of the safety. `@` keeps it from firing on
+ * `@blobatar/react`, which literally contains `@blobatar/react` — that is what
+ * makes the transform idempotent, and idempotence is what lets someone re-run
+ * it on a half-migrated tree without thinking. `\w`, `/` and `-` keep it off
+ * `myblobatar/react`, `vendor/blobatar/react` and `not-blobatar/react`. A
+ * leading `\b` alone is not enough for the last of those: `-` is a non-word
+ * character, so the boundary matches right after it and the codemod would
+ * happily rewrite somebody else's package.
+ */
+const SPECIFIER = /(?<![@\w/-])blobatar\/(react|vue)\b/g;
+
+export interface Change {
+  /** 1-indexed line the rewrite landed on. */
+  line: number;
+  from: string;
+  to: string;
+}
+
+export interface Result {
+  code: string;
+  changes: Change[];
+}
+
+/** Rewrites one file's contents. Returns the original string when nothing matched. */
+export function transform(code: string): Result {
+  const changes: Change[] = [];
+  const out = code.replace(SPECIFIER, (match, framework: "react" | "vue", offset: number) => {
+    changes.push({
+      line: code.slice(0, offset).split("\n").length,
+      from: match,
+      to: MOVES[framework],
+    });
+    return MOVES[framework];
+  });
+  return { code: out, changes };
+}
+
+/**
+ * Whether a file is worth opening at all.
+ *
+ * Extension-based rather than content-based: a codemod that reads every file in
+ * a repository to decide is slower than one that reads the ones that could
+ * possibly match, and the cost of a false negative here is a specifier the
+ * consumer fixes by hand rather than silent breakage.
+ */
+export const MIGRATABLE = /\.(m?[jt]sx?|vue|svelte|astro|json|md|mdx|html)$/;
+
+/** Directories never worth descending into. */
+export const SKIP = new Set([".git", "node_modules", "dist", "build", ".next", ".turbo", "coverage", "out"]);

--- a/packages/codemod/test/codemod.test.ts
+++ b/packages/codemod/test/codemod.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { MIGRATABLE, transform } from "../src/index";
+
+describe("rewriting specifiers", () => {
+  const FORMS: [string, string, string][] = [
+    ["named import", 'import { Blobatar } from "blobatar/react";', 'import { Blobatar } from "@blobatar/react";'],
+    ["single quotes", "import { Blobatar } from 'blobatar/vue';", "import { Blobatar } from '@blobatar/vue';"],
+    ["side-effect import", 'import "blobatar/react";', 'import "@blobatar/react";'],
+    ["dynamic import", 'const m = await import("blobatar/vue");', 'const m = await import("@blobatar/vue");'],
+    ["require", 'const { Blobatar } = require("blobatar/react");', 'const { Blobatar } = require("@blobatar/react");'],
+    ["export from", 'export { Blobatar } from "blobatar/react";', 'export { Blobatar } from "@blobatar/react";'],
+    ["type import", 'import type { BlobatarProps } from "blobatar/react";', 'import type { BlobatarProps } from "@blobatar/react";'],
+    ["a json dependency key", '{ "blobatar/react": "2.x" }', '{ "@blobatar/react": "2.x" }'],
+    ["prose in a comment", "// see blobatar/react for the union", "// see @blobatar/react for the union"],
+  ];
+
+  for (const [what, before, after] of FORMS) {
+    test(what, () => expect(transform(before).code).toBe(after));
+  }
+
+  test("reports the line each rewrite landed on", () => {
+    const { changes } = transform('a\nimport "blobatar/react";\nb\nimport "blobatar/vue";\n');
+    expect(changes.map((c) => [c.line, c.to])).toEqual([
+      [2, "@blobatar/react"],
+      [4, "@blobatar/vue"],
+    ]);
+  });
+});
+
+describe("what it must not touch", () => {
+  /**
+   * The property that makes the codemod safe to run twice, or to run on a
+   * partially-migrated tree — which is what actually happens, because people
+   * migrate one directory, get interrupted, and come back.
+   */
+  test("running it on already-migrated code is a no-op", () => {
+    const migrated = 'import { Blobatar } from "@blobatar/react";';
+    expect(transform(migrated).code).toBe(migrated);
+    expect(transform(migrated).changes).toEqual([]);
+  });
+
+  test("transforming twice is the same as transforming once", () => {
+    const src = 'import { Blobatar } from "blobatar/react";';
+    const once = transform(src).code;
+    expect(transform(once).code).toBe(once);
+  });
+
+  test("leaves core entry points alone", () => {
+    for (const kept of ["blobatar", "blobatar/blob", "blobatar/uri", "blobatar/expression", "blobatar/motion.css", "blobatar/internal"]) {
+      const src = `import x from "${kept}";`;
+      expect(transform(src).code).toBe(src);
+    }
+  });
+
+  test("does not fire on a longer word that merely starts the same", () => {
+    // `blobatar/reactive` is not `@blobatar/react`, and a word-boundary-free
+    // regex would have quietly produced `@blobatar/reactive`.
+    const src = 'import x from "blobatar/reactive";';
+    expect(transform(src).code).toBe(src);
+  });
+
+  test("does not fire inside a longer package name", () => {
+    const src = 'import x from "not-blobatar/react";';
+    expect(transform(src).changes).toEqual([]);
+  });
+});
+
+describe("which files it opens", () => {
+  test("covers the ecosystems an adapter is used from", () => {
+    for (const name of ["a.ts", "a.tsx", "a.js", "a.jsx", "a.mts", "a.mjs", "App.vue", "App.svelte", "page.astro", "package.json", "README.md", "index.html"])
+      expect(MIGRATABLE.test(name)).toBe(true);
+  });
+
+  test("skips what could not contain a specifier", () => {
+    for (const name of ["logo.svg", "styles.css", "bun.lock", "photo.png"])
+      expect(MIGRATABLE.test(name)).toBe(false);
+  });
+});

--- a/packages/codemod/tsconfig.build.json
+++ b/packages/codemod/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/index.ts"]
+}

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // No React in this package, and the root config declares it for the library.
+    "types": ["bun"]
+  },
+  "include": ["src", "test", "scripts"]
+}

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@blobatar/harness",
+  "version": "2.1.0",
+  "private": true,
+  "//private": "Never published. It exists to hold the one test that no single package can own — the cross-adapter equivalence check — and a published package would have to declare every adapter as a dependency, which would drag all of them into any install.",
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "bun run typecheck && bun test"
+  },
+  "devDependencies": {
+    "@blobatar/react": "workspace:*",
+    "@blobatar/vue": "workspace:*",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "blobatar": "workspace:*",
+    "react": "^19",
+    "react-dom": "^19",
+    "vue": "^3.5.0"
+  }
+}

--- a/packages/harness/test/adapters.test.ts
+++ b/packages/harness/test/adapters.test.ts
@@ -7,11 +7,18 @@ import {
   type ComponentObjectPropsOptions,
 } from "vue";
 import { renderToString } from "vue/server-renderer";
-import { Blobatar as React_ } from "../src/react";
-import { Blobatar as Vue_ } from "../src/vue";
+import { Blobatar as React_ } from "@blobatar/react";
+import { Blobatar as Vue_ } from "@blobatar/vue";
 
 /**
  * The adapters must agree.
+ *
+ * Imported by package name, not by relative path into `blobatar/src`. That is
+ * the difference this file gained when it moved out of the library: it now
+ * resolves each adapter through its own published `exports` map and its built
+ * `dist`, so a broken export path or a build that drops the component fails
+ * here rather than in a consumer's install. Nothing in this package aliases
+ * `blobatar/*` back to source, deliberately — see `tsconfig.json`.
  *
  * An adapter owns the outer element and nothing else — it adds no geometry and
  * no defaults of its own — so two adapters handed the same name and the same
@@ -61,6 +68,41 @@ const picture = (markup: string) => {
 
 const attr = (markup: string, name: string) =>
   markup.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1];
+
+/**
+ * Agreement is not enough on its own.
+ *
+ * Every assertion below compares one adapter against another, and two adapters
+ * that both render nothing agree perfectly. That is not a hypothetical: the
+ * first build of `@blobatar/react` in this workspace emitted
+ * `export{a as Blobatar}` with no `a`, and PR #9's Preact adapter returned a
+ * raw DOM node from a function component, which Preact dropped silently for an
+ * empty string — with a clean typecheck and a green test suite in both cases.
+ *
+ * So each adapter is asserted to produce something before any of them are
+ * compared. A new adapter gets a line here and in the case table below; either
+ * alone leaves a hole.
+ */
+describe("every adapter renders a blobatar at all", () => {
+  const ADAPTERS: [string, (p: Record<string, unknown>) => string | Promise<string>][] = [
+    ["@blobatar/react", react],
+    ["@blobatar/vue", vue],
+  ];
+
+  for (const [name, render] of ADAPTERS) {
+    test(`${name}: static`, async () => {
+      const markup = await render({ name: "alain" });
+      expect(markup.length).toBeGreaterThan(0);
+      expect(markup).toContain("data:image/svg+xml");
+    });
+
+    test(`${name}: animated`, async () => {
+      const markup = await render({ name: "alain", animate: "always" });
+      expect(markup.length).toBeGreaterThan(0);
+      expect(markup).toContain("<svg");
+    });
+  }
+});
 
 describe("the adapters render the same blobatar", () => {
   const CASES: [string, Record<string, unknown>][] = [

--- a/packages/harness/test/packaging.test.ts
+++ b/packages/harness/test/packaging.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+
+/**
+ * What each adapter *ships*, read rather than run.
+ *
+ * This moved here from `blobatar`'s `scripts/smoke.mjs` when the adapters left
+ * core, and it had to move rather than be dropped: it is the only check that
+ * sees a build-mode mistake. A package built against the development JSX
+ * transform passes every rendering assertion in this repo — Node resolves
+ * `react/jsx-dev-runtime` and `jsxDEV` exists, so the component renders — and
+ * then throws `jsxDEV is not a function` in any consumer bundling for
+ * production. Nothing observable at runtime here distinguishes the two, so the
+ * emitted specifier itself is the assertion.
+ *
+ * Core's copy still runs, over an empty allow-list: it imports nothing external
+ * at all now. This one is where the list is non-empty, and therefore where the
+ * bug can actually hide.
+ */
+
+const require_ = createRequire(import.meta.url);
+const read = (pkg: string) => readFileSync(require_.resolve(pkg), "utf8");
+
+const ADAPTERS: [string, string[]][] = [
+  ["@blobatar/react", ["blobatar", "blobatar/react", "blobatar/internal", "blobatar/uri", "react", "react/jsx-runtime"]],
+  ["@blobatar/vue", ["blobatar", "blobatar/vue", "blobatar/internal", "blobatar/uri", "vue"]],
+];
+
+const DEV_ONLY: [string, string][] = [
+  ["jsx-dev-runtime", "the development JSX transform — it throws in production bundlers"],
+  ["jsxDEV", "a call into the development JSX transform"],
+  ["process.env", "a bare `process` reference — undefined in browsers and in Workers"],
+];
+
+describe("what the adapters ship", () => {
+  for (const [pkg, allowed] of ADAPTERS) {
+    test(`${pkg} ships production code`, () => {
+      const code = read(pkg);
+      for (const [needle, why] of DEV_ONLY) {
+        expect(code, `${pkg} contains ${needle} — ${why}`).not.toContain(needle);
+      }
+    });
+
+    test(`${pkg} imports only what it declares`, () => {
+      const code = read(pkg);
+      const specifiers = [...code.matchAll(/from\s*["']([^"']+)["']/g)].map((m) => m[1]!);
+      const external = specifiers.filter((s) => !s.startsWith("."));
+      for (const s of external) {
+        expect(allowed, `${pkg} imports ${s}, which it does not declare`).toContain(s);
+      }
+      // Core must be imported, never inlined — that is the whole point of the
+      // split. An adapter that bundled the renderer would ship a second copy of
+      // it to anyone using two frameworks, and would silently stop tracking
+      // core's version.
+      //
+      // Asserted as "some entry point of core", not a specific one, because the
+      // two are legitimately different right now: an adapter that re-exports a
+      // deprecated subpath imports `blobatar/react`, and one written against
+      // the split imports `blobatar/internal`. Both are core. Naming one would
+      // make this test fail on a shape it should accept, and naming neither
+      // would let a bundled copy through.
+      expect(
+        external.some((s) => s === "blobatar" || s.startsWith("blobatar/")),
+        `${pkg} inlines the renderer instead of importing it`,
+      ).toBe(true);
+    });
+  }
+});
+
+/**
+ * The half of lockstep that tooling cannot give you.
+ *
+ * `fixed` in `.changeset/config.json` keeps the published versions in step. It
+ * does nothing about *installs*: npm resolves each package independently, so
+ * `@blobatar/react@4` next to `blobatar@3` is a clean install and a wrong
+ * picture, because under ADR-0008 the major names the generation.
+ *
+ * The exact-major peer range is what refuses that install. It is asserted here
+ * rather than trusted because it is exactly the kind of field release tooling
+ * rewrites on its way past: `changeset version` updates workspace ranges, and
+ * a rewrite to `^3.0.0` would permit the pair this range exists to forbid.
+ *
+ * Deriving the expected range from core's own version is what makes that
+ * catchable. On the release commit — where every version bumps at once — this
+ * test is the thing that fails if the range did not bump with them, or bumped
+ * into a caret. Hard-coding the major here would make it pass by construction
+ * and guard nothing.
+ */
+describe("the adapters pin core to one major", () => {
+  const core = require_("blobatar/package.json") as { version: string };
+  const major = core.version.split(".")[0];
+
+  for (const [pkg] of ADAPTERS) {
+    test(`${pkg} peer-depends on blobatar@${major}.x exactly`, () => {
+      const manifest = require_(`${pkg}/package.json`) as {
+        version: string;
+        peerDependencies?: Record<string, string>;
+      };
+      expect(manifest.peerDependencies?.blobatar).toBe(`${major}.x`);
+      // Lockstep: the adapter's own version must be core's version.
+      expect(manifest.version).toBe(core.version);
+    });
+  }
+});

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "//paths": "Deliberately none. Every other workspace member aliases `blobatar/*` to source so a curve edit shows up on save; this one must not, because what it is testing is the adapters as a consumer receives them. Resolving through the real `exports` maps is the point.",
+  "include": ["test"]
+}

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Alain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,51 @@
+# @blobatar/react
+
+React adapter for [blobatar](https://github.com/Alain00/blobatar) — deterministic
+geometric avatars generated from any string.
+
+```sh
+bun add @blobatar/react blobatar
+```
+
+`blobatar` is a peer dependency: the adapter carries no renderer of its own.
+
+```tsx
+import { Blobatar } from "@blobatar/react";
+
+<Blobatar name={user.email} size={48} />
+```
+
+Animated blobatars need the stylesheet, and render as inline SVG rather than an
+`<img>` — `:hover` never fires inside an `<img>`, so the two modes cannot be
+combined:
+
+```tsx
+import "blobatar/motion.css";
+
+<Blobatar name={user.email} animate="hover" />
+```
+
+Full option reference lives in the [main README](https://github.com/Alain00/blobatar#readme).
+
+## Versioning
+
+Every package in the set publishes the same version, and the major names the
+**generation** — the frozen seed-to-look mapping. `@blobatar/react@2` renders
+gen2, exactly as `blobatar@2` does. Upgrading a major is the opt-in to your
+users' avatars changing, so the peer range on `blobatar` is an exact major
+rather than `^`: a mixed pair is not a version skew, it is the wrong picture.
+
+## Coming from `blobatar/react`
+
+`blobatar/react` still exists and still works. This package re-exports it, so the
+two are the same component rather than two copies and cannot drift. That subpath
+is deprecated and is removed in v3 — there is no hurry, and no risk in waiting.
+
+```sh
+bunx blobatar-codemod .
+bun add @blobatar/react
+```
+
+The codemod rewrites every `blobatar/react` specifier it finds, in imports,
+`require`, dynamic `import()` and prose, and is safe to run twice. It does not
+install anything; that command is yours.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@blobatar/react",
+  "version": "2.1.0",
+  "description": "React adapter for blobatar — deterministic geometric avatars.",
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun scripts/build.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "bun run typecheck"
+  },
+  "//peerDependencies": "`blobatar` is pinned to an exact major, not `^3`. Every package in this set publishes the same version (`.changeset/config.json`), and npm does not enforce that at install time — without the exact range, `@blobatar/react@4` resolves happily alongside `blobatar@3` and renders a different generation's faces from a package the consumer believes is current. Under ADR-0008 the major names the generation, so a mixed pair is not a version skew, it is the wrong picture. `packages/harness` asserts this range rather than trusting it, because release tooling rewrites workspace ranges and would quietly turn it into a caret.",
+  "peerDependencies": {
+    "blobatar": "2.x",
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "blobatar": "workspace:*",
+    "react": "^19"
+  },
+  "keywords": [
+    "blobatar",
+    "avatar",
+    "identicon",
+    "react",
+    "svg",
+    "deterministic"
+  ],
+  "license": "MIT",
+  "author": "Alain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/react"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues",
+  "//check": "No `bun run build` here. The build is a turbo task that `check` depends on, so it runs once for the whole workspace before any check reads a `dist` — a check that rebuilt its own package would delete `dist` out from under a concurrent check in another one."
+}

--- a/packages/react/scripts/build.ts
+++ b/packages/react/scripts/build.ts
@@ -1,0 +1,50 @@
+/**
+ * Publish build for the React adapter.
+ *
+ * Nothing of `blobatar` is inlined. The external list is the whole point of the
+ * split: core is a peer dependency resolved at the consumer's install, so a
+ * React app and a Vue app on the same page would share one renderer rather than
+ * carrying a private copy each — which is what the standalone-entry build in
+ * `packages/blobatar/scripts/build.ts` deliberately does for *its* entries, and
+ * the reason that trade is stated there rather than assumed here.
+ */
+
+import { rmSync } from "node:fs";
+import { $ } from "bun";
+
+rmSync("dist", { recursive: true, force: true });
+
+const build = await Bun.build({
+  entrypoints: ["src/index.tsx"],
+  outdir: "dist",
+  target: "browser",
+  format: "esm",
+  minify: true,
+  sourcemap: "linked",
+  external: ["blobatar", "blobatar/react", "blobatar/internal", "blobatar/uri", "react", "react/jsx-runtime", "react/jsx-dev-runtime"],
+  // Carried over from core's build, and for the same reason: Bun picks the JSX
+  // runtime off `process.env.NODE_ENV`, and a publish build run from a normal
+  // shell has it unset — so without this the package ships `react/jsx-dev-runtime`
+  // calls that resolve fine under Node and die in any consumer bundling for
+  // production, where that specifier carries no `jsxDEV`. Stated here rather
+  // than left to the shell so the output does not depend on who ran it.
+  define: { "process.env.NODE_ENV": '"production"' },
+});
+
+if (!build.success) {
+  for (const log of build.logs) console.error(log);
+  process.exit(1);
+}
+
+for (const out of build.outputs) {
+  if (out.kind !== "sourcemap") continue;
+  const map = await Bun.file(out.path).json();
+  delete map.sourcesContent;
+  await Bun.write(out.path, JSON.stringify(map));
+}
+
+await $`bunx tsc -p tsconfig.build.json`;
+
+for (const out of build.outputs) {
+  if (out.kind === "entry-point") console.log(`✓ ${out.path.replace(process.cwd() + "/", "")}`);
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * `@blobatar/react` — the React adapter's published name.
+ *
+ * ## Why this file re-exports instead of holding the component
+ *
+ * The component still lives in `blobatar/react`, and moving it here is a v3
+ * change rather than a v2 one. That is forced by ADR-0008, not by convenience.
+ *
+ * `blobatar/react` is a published entry point with consumers. Keeping it
+ * working while the implementation lives in a separate package would mean core
+ * depending on this package, which depends on core — and the alternative,
+ * shipping a second copy of the component from core, is two definitions of the
+ * same component drifting inside one release. So the implementation cannot
+ * leave core until `blobatar/react` is allowed to disappear.
+ *
+ * That is a major. And under ADR-0008 a major is not free: the package major
+ * *is* the generation selector, so `blobatar@3` means gen3. There is no spare
+ * major to spend on a repackaging, which means the implementation moves when
+ * gen3 ships and not before.
+ *
+ * What this package does deliver today is the name. A consumer installs
+ * `@blobatar/react` now and never edits an import again — and `@blobatar/svelte`,
+ * `@blobatar/solid` and `@blobatar/preact` arrive as real implementations
+ * alongside it rather than as a second tier beside two privileged subpaths.
+ *
+ * At v3 this file grows the component, `blobatar/react` is deleted, and core's
+ * `peerDependencies` finally empty out. Nothing a consumer wrote has to change.
+ */
+
+import { Blobatar as Component } from "blobatar/react";
+
+export type { BlobatarProps } from "blobatar/react";
+
+/**
+ * Bound through a `const`, and this is not stylistic.
+ *
+ * A module whose body is *nothing but* named re-exports is the shape that makes
+ * Bun 1.3.14 emit `export{a as Blobatar}` with no `a` anywhere, and Node throws
+ * `error: "a" is not declared in this file` the moment it links. `VERSION` in
+ * core's `src/index.ts` carries the full account of the same bug.
+ *
+ * Written as plain re-exports first, and `packages/harness` failed on it
+ * immediately — which is the reason that package resolves adapters through
+ * their published `exports` maps and their built `dist` instead of importing
+ * source. Core's note says the bug needs `splitting: true`; it does not. This
+ * build never turns splitting on and hit it anyway.
+ *
+ * The explicit `typeof Component` annotation is load-bearing too. Without it
+ * the Vue adapter's declaration emit fails with TS2883, because
+ * `defineComponent`'s inferred type cannot be named without reaching into
+ * core's internal declaration files. Annotating against the local binding keeps
+ * the emitted `.d.ts` portable, and keeps both adapters written the same way.
+ */
+export const Blobatar: typeof Component = Component;

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Emptied deliberately. Declarations must resolve `blobatar` through its
+    // real `exports` map rather than the source alias development uses, or the
+    // emitted `.d.ts` would reference paths that exist only inside this repo.
+    "paths": {},
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // `blobatar` resolves to source here, the same way the apps do it, so
+    // editing the renderer shows up without a build in between. What *ships*
+    // resolves through the real `exports` map — `tsconfig.build.json` clears
+    // these paths for the declaration emit, and `scripts/build.ts` externalizes
+    // `blobatar` entirely, so nothing of core is inlined into this package.
+    "paths": {
+      "blobatar": ["../blobatar/src/index.ts"],
+      "blobatar/react": ["../blobatar/src/react.tsx"],
+      "blobatar/uri": ["../blobatar/src/uri.ts"],
+      "blobatar/internal": ["../blobatar/src/internal.ts"]
+    }
+  },
+  "include": ["src", "scripts"]
+}

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Alain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,59 @@
+# @blobatar/vue
+
+Vue 3 adapter for [blobatar](https://github.com/Alain00/blobatar) — deterministic
+geometric avatars generated from any string.
+
+```sh
+bun add @blobatar/vue blobatar
+```
+
+`blobatar` is a peer dependency: the adapter carries no renderer of its own.
+
+```vue
+<script setup lang="ts">
+import { Blobatar } from "@blobatar/vue";
+</script>
+
+<template>
+  <Blobatar :name="user.email" :size="48" />
+</template>
+```
+
+Animated blobatars need the stylesheet, and render as inline SVG rather than an
+`<img>` — `:hover` never fires inside an `<img>`, so the two modes cannot be
+combined:
+
+```vue
+<script setup lang="ts">
+import "blobatar/motion.css";
+</script>
+
+<template>
+  <Blobatar :name="user.email" animate="hover" />
+</template>
+```
+
+Full option reference lives in the [main README](https://github.com/Alain00/blobatar#readme).
+
+## Versioning
+
+Every package in the set publishes the same version, and the major names the
+**generation** — the frozen seed-to-look mapping. `@blobatar/vue@2` renders
+gen2, exactly as `blobatar@2` does. Upgrading a major is the opt-in to your
+users' avatars changing, so the peer range on `blobatar` is an exact major
+rather than `^`: a mixed pair is not a version skew, it is the wrong picture.
+
+## Coming from `blobatar/vue`
+
+`blobatar/vue` still exists and still works. This package re-exports it, so the
+two are the same component rather than two copies and cannot drift. That subpath
+is deprecated and is removed in v3 — there is no hurry, and no risk in waiting.
+
+```sh
+bunx blobatar-codemod .
+bun add @blobatar/vue
+```
+
+The codemod rewrites every `blobatar/vue` specifier it finds, in imports,
+`require`, dynamic `import()` and prose, and is safe to run twice. It does not
+install anything; that command is yours.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@blobatar/vue",
+  "version": "2.1.0",
+  "description": "Vue 3 adapter for blobatar — deterministic geometric avatars.",
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun scripts/build.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "bun run typecheck"
+  },
+  "//peerDependencies": "`blobatar` is pinned to an exact major, not `^3`. Every package in this set publishes the same version (`.changeset/config.json`), and npm does not enforce that at install time — without the exact range, `@blobatar/react@4` resolves happily alongside `blobatar@3` and renders a different generation's faces from a package the consumer believes is current. Under ADR-0008 the major names the generation, so a mixed pair is not a version skew, it is the wrong picture. `packages/harness` asserts this range rather than trusting it, because release tooling rewrites workspace ranges and would quietly turn it into a caret.",
+  "peerDependencies": {
+    "blobatar": "2.x",
+    "vue": ">=3"
+  },
+  "devDependencies": {
+    "blobatar": "workspace:*",
+    "vue": "^3.5.0"
+  },
+  "keywords": [
+    "blobatar",
+    "avatar",
+    "identicon",
+    "vue",
+    "svg",
+    "deterministic"
+  ],
+  "license": "MIT",
+  "author": "Alain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/vue"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues",
+  "//check": "No `bun run build` here. The build is a turbo task that `check` depends on, so it runs once for the whole workspace before any check reads a `dist` — a check that rebuilt its own package would delete `dist` out from under a concurrent check in another one."
+}

--- a/packages/vue/scripts/build.ts
+++ b/packages/vue/scripts/build.ts
@@ -1,0 +1,43 @@
+/**
+ * Publish build for the Vue 3 adapter.
+ *
+ * Nothing of `blobatar` is inlined. The external list is the whole point of the
+ * split: core is a peer dependency resolved at the consumer's install, so a
+ * React app and a Vue app on the same page would share one renderer rather than
+ * carrying a private copy each — which is what the standalone-entry build in
+ * `packages/blobatar/scripts/build.ts` deliberately does for *its* entries, and
+ * the reason that trade is stated there rather than assumed here.
+ */
+
+import { rmSync } from "node:fs";
+import { $ } from "bun";
+
+rmSync("dist", { recursive: true, force: true });
+
+const build = await Bun.build({
+  entrypoints: ["src/index.ts"],
+  outdir: "dist",
+  target: "browser",
+  format: "esm",
+  minify: true,
+  sourcemap: "linked",
+  external: ["blobatar", "blobatar/vue", "blobatar/internal", "blobatar/uri", "vue"],
+});
+
+if (!build.success) {
+  for (const log of build.logs) console.error(log);
+  process.exit(1);
+}
+
+for (const out of build.outputs) {
+  if (out.kind !== "sourcemap") continue;
+  const map = await Bun.file(out.path).json();
+  delete map.sourcesContent;
+  await Bun.write(out.path, JSON.stringify(map));
+}
+
+await $`bunx tsc -p tsconfig.build.json`;
+
+for (const out of build.outputs) {
+  if (out.kind === "entry-point") console.log(`✓ ${out.path.replace(process.cwd() + "/", "")}`);
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * `@blobatar/vue` — the React adapter's published name.
+ *
+ * ## Why this file re-exports instead of holding the component
+ *
+ * The component still lives in `blobatar/vue`, and moving it here is a v3
+ * change rather than a v2 one. That is forced by ADR-0008, not by convenience.
+ *
+ * `blobatar/vue` is a published entry point with consumers. Keeping it
+ * working while the implementation lives in a separate package would mean core
+ * depending on this package, which depends on core — and the alternative,
+ * shipping a second copy of the component from core, is two definitions of the
+ * same component drifting inside one release. So the implementation cannot
+ * leave core until `blobatar/vue` is allowed to disappear.
+ *
+ * That is a major. And under ADR-0008 a major is not free: the package major
+ * *is* the generation selector, so `blobatar@3` means gen3. There is no spare
+ * major to spend on a repackaging, which means the implementation moves when
+ * gen3 ships and not before.
+ *
+ * What this package does deliver today is the name. A consumer installs
+ * `@blobatar/vue` now and never edits an import again — and `@blobatar/svelte`,
+ * `@blobatar/solid` and `@blobatar/preact` arrive as real implementations
+ * alongside it rather than as a second tier beside two privileged subpaths.
+ *
+ * At v3 this file grows the component, `blobatar/vue` is deleted, and core's
+ * `peerDependencies` finally empty out. Nothing a consumer wrote has to change.
+ */
+
+import { Blobatar as Component } from "blobatar/vue";
+
+
+/**
+ * Bound through a `const`, and this is not stylistic.
+ *
+ * A module whose body is *nothing but* named re-exports is the shape that makes
+ * Bun 1.3.14 emit `export{a as Blobatar}` with no `a` anywhere, and Node throws
+ * `error: "a" is not declared in this file` the moment it links. `VERSION` in
+ * core's `src/index.ts` carries the full account of the same bug.
+ *
+ * Written as plain re-exports first, and `packages/harness` failed on it
+ * immediately — which is the reason that package resolves adapters through
+ * their published `exports` maps and their built `dist` instead of importing
+ * source. Core's note says the bug needs `splitting: true`; it does not. This
+ * build never turns splitting on and hit it anyway.
+ *
+ * The explicit `typeof Component` annotation is load-bearing too. Without it
+ * the Vue adapter's declaration emit fails with TS2883, because
+ * `defineComponent`'s inferred type cannot be named without reaching into
+ * core's internal declaration files. Annotating against the local binding keeps
+ * the emitted `.d.ts` portable, and keeps both adapters written the same way.
+ */
+export const Blobatar: typeof Component = Component;

--- a/packages/vue/tsconfig.build.json
+++ b/packages/vue/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Emptied deliberately. Declarations must resolve `blobatar` through its
+    // real `exports` map rather than the source alias development uses, or the
+    // emitted `.d.ts` would reference paths that exist only inside this repo.
+    "paths": {},
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // The root config declares ["bun", "react"], for the library that still
+    // contains a React adapter. This package has no React dependency and must
+    // not acquire one by inheritance.
+    "types": ["bun"],
+    // See `packages/react/tsconfig.json` — same aliasing, same reason.
+    "paths": {
+      "blobatar": ["../blobatar/src/index.ts"],
+      "blobatar/vue": ["../blobatar/src/vue.ts"],
+      "blobatar/uri": ["../blobatar/src/uri.ts"],
+      "blobatar/internal": ["../blobatar/src/internal.ts"]
+    }
+  },
+  "include": ["src", "scripts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -65,8 +65,15 @@
       "cache": false
     },
 
+    // `["^build", "build"]`, not `["^build"]`, and the difference is a race that
+    // only shows up under concurrency. A `check` script that runs its own build
+    // starts by deleting `dist` — and other packages' checks read that `dist`
+    // through the real `exports` map, so one package's check could wipe the
+    // declarations another was mid-way through typechecking. Depending on the
+    // `build` task instead means it happens once, before anything reads it, and
+    // no `check` script needs to invoke a build itself.
     "check": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "build"]
     }
   }
 }


### PR DESCRIPTION
Stacked on #10 — review that first. Second of five PRs in the package split ([plan](https://claude.ai/code/artifact/a52ed138-b0ea-4a07-aea4-853ed49f5173)).

Ships `@blobatar/react` and `@blobatar/vue`, adds `blobatar/internal`, moves the drift harness into its own package, and turns on lockstep releases. **Non-breaking** — `blobatar/react` and `blobatar/vue` keep working unchanged.

## The implementation does not move yet, and that is forced

The plan said this PR would extract the components into their own packages and empty core's `peerDependencies`. It can't, and the reason is ADR-0008.

`blobatar/react` is a published entry point with consumers. Keeping it working while the component lives in a separate package means core depending on the adapter that depends on core. The only alternative — shipping a second copy of the component from core — is two definitions of one component drifting inside a release. So the component cannot leave until that subpath is allowed to disappear, and that is a major.

Under ADR-0008 a major is not spare capacity: the package major **is** the generation selector, so `blobatar@3` means gen3. There is no major to spend on repackaging alone. The component moves when gen3 ships.

What this PR does deliver is the consumer-facing shape: a consumer installs `@blobatar/react` today and never edits an import again, and `@blobatar/svelte`, `@blobatar/solid` and `@blobatar/preact` arrive as peers rather than as a second tier beside two privileged subpaths. Core's peers empty out at v3.

If you'd rather spend a major on the split and decouple it from generations, that's a different plan and ADR-0008 is the thing to rewrite — say so and I'll redo this.

## `blobatar/internal`

`_parts`, `_layout` and `serializeVars`, stated rather than implied. `_parts` was underscored and documented as "not public API", which held while every caller lived in the same directory; it now crosses a published boundary.

Its contract: **changes only on a major, together with every `@blobatar/*` package.** That is truthful only because the set releases in lockstep, which is the point. It is not a general-purpose API — `blobatar()` and `blobatarUri()` remain the public answers for rendering markup.

## Two bugs the new structure caught immediately

**An invalid `exports` map.** I first wrote the explanatory `"//internal"` comment *inside* the `exports` object, following the repo's `//`-key idiom. Exports keys must all begin with `.` — Node and tsc reject the entire map. Every subpath silently stopped resolving. Moved to the top level next to `"//exports"`.

**`@blobatar/react` shipped a module that could not link.** Written as plain re-exports, the built output was `export{a as Blobatar}` with no `a` anywhere — the Bun 1.3.14 bug that `VERSION` in core's `src/index.ts` documents. Node throws `error: "a" is not declared in this file` on import.

Core's note says that bug needs `splitting: true`. **It does not.** Neither adapter build turns splitting on and both hit it. Worth knowing before anyone trusts that caveat again.

Both adapters now bind through `export const Blobatar: typeof Component = Component`. The explicit annotation is load-bearing too — without it Vue's declaration emit fails TS2883, because `defineComponent`'s inferred type can't be named without reaching into core's internal `.d.ts` files.

## The harness

`test/adapters.test.ts` moved to `packages/harness` — private, never published, dev-depending on every adapter. It imports adapters **by package name**, so it resolves through their real `exports` maps and built `dist` rather than core's source. That change is what caught the unlinkable module on its first run.

It also gains an assertion the old file had no reason to make:

```ts
describe("every adapter renders a blobatar at all", () => { ... })
```

Every other assertion compares one adapter against another, and two adapters that both render nothing agree perfectly. Not hypothetical — that is exactly how PR #9's Preact adapter passed typecheck and 154 tests while rendering an empty string.

## Verification

`turbo run check` green from a cold cache: 11 tasks, 130 core tests (154 minus the 24 that moved), 24 harness tests through the published exports, size budgets, composition gate, builds, and the Node link smoke — which now links `blobatar/internal` too, since an unlinkable `internal` would break every adapter at once while `bun test` stayed green.

`npm pack` verified for all three publishable packages. `changeset status` resolves the lockstep set to one minor across `blobatar`, `@blobatar/react` and `@blobatar/vue`.

## Next

PR 3 re-baselines the size budgets; PR 4 the release pipeline; PR 5 the three new adapters, each with its own build and its own harness row.
