### PR TITLE
chore: a size gate for what the packages ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,12 @@ jobs:
       - name: Adapter drift harness
         run: bunx turbo run test --filter=@blobatar/harness
 
+      # Both gates, and they measure different things — core's reads its own
+      # source, the harness's resolves every package by name through its built
+      # `exports` map. Unfiltered rather than named, so an adapter added in
+      # PR 5 is measured the moment its package has a `size` script.
       - name: Size budgets
-        run: bunx turbo run size --filter=blobatar
+        run: bunx turbo run size
 
       # `probe-compose.ts` warns and exits 0 when it finds no browser, so that a
       # local run without one is not a hard stop. In CI that would turn the only
@@ -59,8 +63,12 @@ jobs:
           google-chrome --version
           firefox --version
 
+      # `--filter=blobatar`, because that is where `scripts/probe-compose.ts`
+      # lives. Filtered to the harness by the split, where there is no `probe`
+      # script — turbo runs zero tasks and exits 0, so the one check that can
+      # see a CSS-versus-geometry divergence has been silently passing since.
       - name: Composition gate
-        run: bunx turbo run probe --filter=@blobatar/harness
+        run: bunx turbo run probe --filter=blobatar
 
       - name: Build
         run: bunx turbo run build

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -270,3 +270,19 @@ _Avoid_: gallery, facepile, grid.
 The landing page's parallax field of blobatars illustrating "millions of
 options". Distinct from the tuning grid, which serves design work, not
 persuasion.
+
+**Source gate** / **Ship gate**:
+The two size budgets, which measure deliberately different things and are worth
+keeping apart by name. The **source gate**
+(`packages/blobatar/scripts/size.ts`) builds consumers that import
+`../../src/*`, so it answers "what does this code tree-shake to" — it is the
+one that catches a palette tweak doubling the colour code, and it depends on no
+build. The **ship gate** (`packages/harness/scripts/size.ts`) resolves every
+package by name through its built `exports` map, so it answers "what does
+`bun add @blobatar/react` cost" and cannot run before those packages are built.
+A component measured by both comes out at two different numbers — core's publish
+build minifies better than a synthetic consumer of its source does — and neither
+is wrong. It lives in the harness because core cannot depend on an adapter
+without making `^build` cyclic.
+_Avoid_: calling either one "the size gate"; the ambiguity is the whole reason
+they have names.

--- a/packages/blobatar/scripts/size.ts
+++ b/packages/blobatar/scripts/size.ts
@@ -8,6 +8,20 @@
  * Budgets are per entry point. The core budget is the one that matters: it is
  * what stops a convenience import from quietly pulling in the React adapter, or
  * a palette tweak from doubling the color code.
+ *
+ * This is the **source gate**, and the name is load-bearing. Every consumer
+ * below imports `../../src/*` and none of them ever touches `dist` or resolves
+ * an `exports` map, so what is measured here is what the source tree-shakes to —
+ * not what the published package costs. The two are not the same number: core's
+ * publish build minifies better than a synthetic consumer of its source does,
+ * and `react` below reads 5336 against 5204 for the same component reached
+ * through `dist`.
+ *
+ * What ships is the **ship gate**, `packages/harness/scripts/size.ts`, which
+ * resolves each package by name. It lives there rather than here because
+ * measuring `@blobatar/react` means depending on it, and core cannot — the
+ * adapter peer-depends on core, so the devDependency back would make turbo's
+ * `^build` graph cyclic.
  */
 
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "check": "bun run typecheck && bun test"
+    "//size": "The second size instrument. Core's measures its own source; this one measures every package's `dist` resolved by name, which is the only place a packaging regression — core stopping being external, a second copy of the renderer — can show up. It lives here because core cannot depend on an adapter without making `^build` cyclic.",
+    "size": "bun scripts/size.ts",
+    "check": "bun run typecheck && bun test && bun run size"
   },
   "devDependencies": {
     "@blobatar/react": "workspace:*",

--- a/packages/harness/scripts/size.ts
+++ b/packages/harness/scripts/size.ts
@@ -1,0 +1,208 @@
+/**
+ * Bundle size gate for what the packages *ship*.
+ *
+ * `packages/blobatar/scripts/size.ts` is the other half of this and measures
+ * something different on purpose: its synthetic consumers import `../../src/*`,
+ * so it measures what the source tree-shakes to. That is the right instrument
+ * for "did a palette tweak double the colour code", and the wrong one for "does
+ * `bun add @blobatar/react` cost what we think", because nothing in it ever
+ * touches a `dist` or resolves an `exports` map.
+ *
+ * This file is the second instrument. It lives here rather than in core for the
+ * reason `packages/harness` exists at all: measuring `@blobatar/react` means
+ * depending on `@blobatar/react`, and core cannot — the adapter peer-depends on
+ * core, so a devDependency the other way makes turbo's `^build` graph cyclic.
+ * Harness already declares every adapter and is never published.
+ *
+ * ## Why the consumer tree is built by hand
+ *
+ * A fixture written inside the workspace and importing `@blobatar/react` does
+ * not measure `dist`. It measures core's *source*, silently:
+ * `packages/react/tsconfig.json` aliases `blobatar/*` back to `../blobatar/src`
+ * so a curve edit shows up without a build, and Bun applies the tsconfig
+ * nearest the *importing* file — which, for `packages/react/dist/index.js`, is
+ * that one. The alias is correct and must stay; it just cannot be in scope
+ * here. Bun.build's `tsconfig` option does not override it (tried — the
+ * per-file lookup wins), so the fixture is built in a tree that contains no
+ * tsconfig at all: each package's `package.json` and `dist` copied under a
+ * scratch `node_modules`, resolved by name through the real `exports` maps.
+ *
+ * Measured through the alias, `@blobatar/react` reported 5342 B rather than
+ * 5228 — a number 114 B off, for core's source, from a fixture that looked
+ * exactly like it was measuring the published package.
+ *
+ * Copied rather than `npm pack`ed, and that is a trade with a known edge.
+ * A tarball would also prove the `files` field, but `npm pack` runs `prepack`,
+ * which for core is `bun run build`, which starts by deleting `dist` — the
+ * exact race `turbo.json` explains under `check`. A gate may not be the thing
+ * that wipes a `dist` another task is reading. CI's `Pack` step covers `files`
+ * on its own, after everything else has finished.
+ */
+
+import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+
+const DIR = "scripts/.consumer";
+const MODULES = `${DIR}/node_modules`;
+
+/** Every package the fixtures below resolve by name, and where it is built. */
+const INSTALLED: { name: string; from: string }[] = [
+  { name: "blobatar", from: "../blobatar" },
+  { name: "@blobatar/react", from: "../react" },
+  { name: "@blobatar/vue", from: "../vue" },
+];
+
+const ENTRIES: {
+  name: string;
+  budget: number;
+  external: string[];
+  source: string;
+  /** Entry file extension. Defaults to a TSX consumer. */
+  ext?: string;
+}[] = [
+  {
+    // The row PR 3 exists for: the number a consumer pays for
+    // `bun add @blobatar/react`, core included, only React external.
+    //
+    // Measured 5228 B gz against the 5204 of the subpath row below, so the
+    // package indirection costs 24 B: one more module in the graph, its `const`
+    // binding, and the re-export. That 24 B is not gated on its own — a delta
+    // between two rows that both track the renderer was a weaker form of the
+    // `alone` rows below, which bound the same file directly and 60x tighter.
+    //
+    // Expect it to track core's `react` row rather than lead it: this is the
+    // same component reached by a different specifier. A change that moves one
+    // and not the other is a packaging change, and there is exactly one of
+    // those in flight — the v3 swap, where the implementation moves into the
+    // package and `blobatar/react` is deleted. On that day the subpath rows go
+    // away and these are what is left.
+    name: "@blobatar/react",
+    budget: 5260,
+    external: ["react"],
+    source: `import { Blobatar } from "@blobatar/react";
+             globalThis.x = Blobatar;`,
+  },
+  {
+    // The deprecated subpath, measured through `dist` rather than through
+    // source. Core's own `react` row measures the same component at 5336 from
+    // `src`, and the 132 B between them is not a regression in either
+    // direction — it is core's publish build minifying better than a synthetic
+    // consumer of its source does. Two numbers for one component is the price
+    // of having two instruments, and the reason each file's header says which
+    // one it is.
+    //
+    // This row is here so the pair delta below has something to subtract, and
+    // it retires with the subpath in v3.
+    name: "blobatar/react",
+    budget: 5240,
+    external: ["react"],
+    source: `import { Blobatar } from "blobatar/react";
+             globalThis.x = Blobatar;`,
+  },
+  {
+    // ~176 B over React, and it is the same ~170 B core's `vue` row already
+    // accounts for: the runtime props table, the string-style merge, and the
+    // `default: undefined` on every prop. Vue surface, not packaging — its
+    // indirection over the subpath row is 27 B against React's 24.
+    name: "@blobatar/vue",
+    budget: 5440,
+    external: ["vue"],
+    ext: "ts",
+    source: `import { Blobatar } from "@blobatar/vue";
+             globalThis.x = Blobatar;`,
+  },
+  {
+    name: "blobatar/vue",
+    budget: 5410,
+    external: ["vue"],
+    ext: "ts",
+    source: `import { Blobatar } from "blobatar/vue";
+             globalThis.x = Blobatar;`,
+  },
+
+  // The two rows below are the only place the externals in each adapter's
+  // `scripts/build.ts` are falsifiable, and finding that out cost a wrong
+  // comment in the first draft of this file.
+  //
+  // The intuition is that inlining core into an adapter would show up as a
+  // consumer paying for the renderer twice. It does not. A consumer of one
+  // adapter has one copy either way — the bundler dedupes what the adapter
+  // inlined against nothing else. And a consumer of *both* adapters already
+  // pays twice with the externals working, because core's publish build emits
+  // standalone entries: `dist/react.js` and `dist/vue.js` each carry their own
+  // renderer, which is the trade stated in `packages/blobatar/scripts/build.ts`
+  // and inherited here by re-export. So no whole-consumer number moves.
+  // Deleting the external list entirely and rebuilding moved the row above by
+  // -11 B, in the wrong direction, and every gate stayed green.
+  //
+  // What does move is the adapter's own `dist`. Bundled with core external, it
+  // is the two-line re-export it is supposed to be. With the externals broken
+  // it was 5217 B — the whole renderer, sitting inside a package that declares
+  // core a peer dependency. That is the shape this catches, and it is worth
+  // catching for a reason bigger than bytes: a package that both peer-depends
+  // on core and carries a private copy renders one generation while resolving
+  // another (ADR-0008), which is the mixed install `packages/harness`'s
+  // packaging test exists to forbid.
+  {
+    // 78 B measured. The budget is loose in ratio and tight in absolute, which
+    // suits a row whose failure mode is two orders of magnitude away — there is
+    // no correct change that puts 30 B into a re-export, and none that puts
+    // 5 kB there either without being exactly the bug described above.
+    name: "@blobatar/react alone",
+    budget: 110,
+    external: ["react", "blobatar", "blobatar/react", "blobatar/internal", "blobatar/uri"],
+    source: `import { Blobatar } from "@blobatar/react";
+             globalThis.x = Blobatar;`,
+  },
+  {
+    name: "@blobatar/vue alone",
+    budget: 110,
+    external: ["vue", "blobatar", "blobatar/vue", "blobatar/internal", "blobatar/uri"],
+    ext: "ts",
+    source: `import { Blobatar } from "@blobatar/vue";
+             globalThis.x = Blobatar;`,
+  },
+];
+
+rmSync(DIR, { recursive: true, force: true });
+for (const pkg of INSTALLED) {
+  const dest = `${MODULES}/${pkg.name}`;
+  mkdirSync(dest, { recursive: true });
+  cpSync(`${pkg.from}/package.json`, `${dest}/package.json`);
+  // The stale tree was removed above, so a missing `dist` throws here rather
+  // than leaving the run to measure whatever was left over from last time.
+  cpSync(`${pkg.from}/dist`, `${dest}/dist`, { recursive: true });
+}
+
+let failed = false;
+
+for (const entry of ENTRIES) {
+  const file = `${DIR}/${entry.name.replace(/\W+/g, "-")}.${entry.ext ?? "tsx"}`;
+  writeFileSync(file, entry.source);
+
+  const build = await Bun.build({
+    entrypoints: [file],
+    target: "browser",
+    minify: true,
+    external: entry.external,
+  });
+
+  if (!build.success) {
+    console.error(`✗ ${entry.name} failed to build`);
+    for (const log of build.logs) console.error(log);
+    failed = true;
+    continue;
+  }
+
+  const raw = await build.outputs[0]!.arrayBuffer();
+  const gz = Bun.gzipSync(new Uint8Array(raw)).byteLength;
+  const ok = gz <= entry.budget;
+  failed ||= !ok;
+
+  console.log(
+    `${ok ? "✓" : "✗"} ${entry.name.padEnd(21)} ${String(gz).padStart(5)} B gz` +
+      ` / ${String(entry.budget).padStart(5)} B  (${Math.round((gz / entry.budget) * 100)}%)`,
+  );
+}
+
+rmSync(DIR, { recursive: true, force: true });
+process.exit(failed ? 1 : 0);

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "//paths": "Deliberately none. Every other workspace member aliases `blobatar/*` to source so a curve edit shows up on save; this one must not, because what it is testing is the adapters as a consumer receives them. Resolving through the real `exports` maps is the point.",
-  "include": ["test"]
+  "include": ["test", "scripts"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -29,12 +29,18 @@
       "dependsOn": ["^build"]
     },
 
-    // Not `dependsOn: ["build"]`, and the reason is in `scripts/size.ts`: the
-    // synthetic consumers import `../../src/*` and never touch `dist`, so this
-    // measures what the source tree-shakes to. Making it wait on a build would
-    // suggest it measures the shipped package, which is exactly the confusion
-    // that file's header warns about.
-    "size": {},
+    // `^build`, and only because a second size gate arrived that needs it.
+    // There are two, measuring deliberately different things: core's
+    // `scripts/size.ts` imports `../../src/*` and never touches `dist`, so it
+    // measures what the source tree-shakes to and depends on nothing — while
+    // `packages/harness/scripts/size.ts` resolves every package by name through
+    // its real `exports` map, so it cannot run before those packages are built.
+    //
+    // `^build` and not `build`: neither gate builds the package it lives in.
+    // Core's reads its own source, and the harness is never built at all.
+    "size": {
+      "dependsOn": ["^build"]
+    },
 
     // Browser-driven, and it reads the stylesheet and geometry from source.
     "probe": {},


### PR DESCRIPTION
Third of five PRs in the package split ([plan](https://claude.ai/code/artifact/a52ed138-b0ea-4a07-aea4-853ed49f5173)). Follows #11, which is merged.

Adds a second size gate. Core's existing budgets measure what the source tree-shakes to; this one measures what `bun add @blobatar/react` actually costs. Nothing published changes, so there is no changeset.

```
✓ @blobatar/react        5228 B gz /  5260 B
✓ blobatar/react         5204 B gz /  5240 B
✓ @blobatar/vue          5404 B gz /  5440 B
✓ blobatar/vue           5377 B gz /  5410 B
✓ @blobatar/react alone    78 B gz /   110 B
✓ @blobatar/vue alone      76 B gz /   110 B
```

Every budget is derived from a measured run. None was regenerated to get green.

## Why it lives in the harness

Measuring `@blobatar/react` means depending on `@blobatar/react`. Core cannot — the adapter peer-depends on core, so a devDependency the other way makes turbo's `^build` graph cyclic. `packages/harness` already declares every adapter and is never published, so it is the only place this can go. `CONTEXT.md` gains a **Source gate** / **Ship gate** entry so the two are not conflated by name.

`size` in `turbo.json` now takes `dependsOn: ["^build"]` — the ship gate resolves packages by name and cannot run before they are built. `^build` and not `build`: neither gate builds the package it lives in. CI runs `turbo run size` unfiltered rather than naming packages, so PR 5's adapters are measured the moment they have a `size` script.

## A fixture inside the workspace measures core's source, silently

This is the part worth reading before trusting any number in the file.

`packages/react/tsconfig.json` aliases `blobatar/*` back to `../blobatar/src`, so a curve edit shows up without a build. Bun applies the tsconfig nearest the **importing** file — which, for `packages/react/dist/index.js`, is that one. So a fixture that imports `@blobatar/react` by name, from anywhere in this workspace, resolves core's *source* and reports a number for it.

It reported 5342 B. The real figure is 5228. Off by 114 B, for the wrong tree, from a fixture that looked exactly like it was measuring the published package.

`Bun.build`'s `tsconfig` option does not override this — the per-file lookup wins. So the fixtures build in a scratch tree that contains no tsconfig at all: each package's `package.json` and `dist` copied under a throwaway `node_modules`, resolved by name through the real `exports` maps.

Copied rather than `npm pack`ed, and that trade has a known edge. A tarball would also prove `files`, but `npm pack` runs `prepack`, which for core is `bun run build`, which opens with `rmSync("dist")` — the exact race `turbo.json` explains under `check`. A gate may not be the thing that wipes a `dist` another task is reading. CI's `Pack` step already covers `files`, after everything else has finished.

## The obvious row does not catch broken externals

The plan expected a "core + adapter" row to catch the adapter inlining core. **It does not**, and I only know that because I broke it on purpose.

Deleting the external list from `packages/react/scripts/build.ts` and rebuilding moved the consumer row by **−11 B**, in the wrong direction, and every gate stayed green. A consumer of one adapter has one copy of the renderer either way — the bundler dedupes what the adapter inlined against nothing else. And a consumer of *both* adapters already pays twice with the externals working, because core's publish build emits standalone entries: `dist/react.js` and `dist/vue.js` each carry their own renderer. So no whole-consumer number moves.

What moves is the adapter's own `dist`. Bundled with core external, it is the two-line re-export it is supposed to be — 78 B. With the externals broken it was 5217 B: the whole renderer, sitting inside a package that declares core a peer dependency. That is the `alone` rows, and they are the only falsifiable check on the externals here.

Worth catching for a reason bigger than bytes. A package that both peer-depends on core and carries a private copy renders one generation while resolving another (ADR-0008) — the mixed install `packages/harness/test/packaging.test.ts` exists to forbid.

I also wrote and then deleted a package-vs-subpath delta assertion. It read well and I could not construct a failure it caught that the `alone` rows missed, so it went.

## Unrelated: the composition gate has been passing on zero tasks

CI runs `turbo run probe --filter=@blobatar/harness`. `probe-compose.ts` lives in `blobatar`, and the harness has no `probe` script, so turbo runs nothing and exits 0. The only check that can see a CSS-versus-geometry divergence has been silently green since #11.

Filter corrected to `blobatar`. Not this PR's job, but it was one line and adjacent to the CI edits.

## Verification

- `rm -rf node_modules && bun install --frozen-lockfile`, cold turbo cache: 14/14 tasks, ~35s. Not just `rm -rf .turbo` — that is how the last hoisting bug got through.
- Both failure modes above were induced and reverted; adapter `dist` files are byte-identical to `main` afterwards.
- `turbo run size` from a cold cache with every `dist` deleted builds its dependencies first and passes.

`release.yml` is untouched. Its size step runs core's source gate before the build, which is still correct; widening it belongs to PR 4.
