### PR TITLE
ci: release every package in the lockstep group, not just core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       # setup-node ships npm 10 with Node 22, and OIDC trusted publishing —
-      # which is how this package authenticates, there is no NPM_TOKEN — landed
+      # which is how these packages authenticate, there is no NPM_TOKEN — landed
       # in npm 11.5.1. On the older client `npm publish` does not even attempt
       # the token exchange; it fails with ENEEDAUTH as if no credentials were
       # configured at all, which is a misleading way to learn this.
@@ -38,34 +38,136 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # Unfiltered, and that is the change the split forces. `bun --filter
+      # blobatar` was every one of these before, which was complete while core
+      # was the only published package and is now a release that never
+      # typechecks, tests or measures the adapters it is about to publish.
+      # The repo already argues this for the local `check` script: a gate that
+      # is a subset of CI goes green on code CI rejects. A release gate that is
+      # a subset of CI is the same mistake with a worse blast radius.
+      #
+      # `probe` is the one CI task deliberately not here: it drives real
+      # browsers, which this runner does not install, and it warns and exits 0
+      # when it finds none. A gate that cannot fail is worse than an absent one.
+      - name: Typecheck
+        run: bunx turbo run typecheck
+
       - name: Tests
-        run: bun --filter blobatar test
+        run: bunx turbo run test
 
       - name: Size budgets
-        run: bun --filter blobatar size
+        run: bunx turbo run size
 
       - name: Build
-        run: bun --filter blobatar build
+        run: bunx turbo run build
 
       - name: Smoke the built package
-        run: bun --filter blobatar smoke
+        run: bunx turbo run smoke
 
-      - name: Refuse to publish a tag that disagrees with package.json
+      # Every lockstep package, not just core. `scripts/publishable.ts` derives
+      # the set from `private` and from `fixed` in `.changeset/config.json`
+      # rather than restating it here — see its header for why the list is not
+      # written down twice, and why this is not `npm publish --workspaces`.
+      #
+      # This is also the check that proves lockstep held. `changeset version`
+      # bumps the group together, so a package whose version disagrees with the
+      # tag means the release commit is not what it appears to be, and the
+      # adapters would publish pinned to a core major that is not shipping.
+      - name: Refuse to publish a tag that disagrees with any package
+        if: github.event_name == 'push'
         run: |
           tag="${GITHUB_REF_NAME#v}"
-          pkg=$(node -p "require('./packages/blobatar/package.json').version")
-          if [ "$tag" != "$pkg" ]; then
-            echo "tag v$tag does not match package.json $pkg" >&2
+          failed=0
+          while IFS=$'\t' read -r name version group; do
+            case "$group" in
+              lockstep)
+                if [ "$version" != "$tag" ]; then
+                  echo "::error::$name is $version, tag says $tag"
+                  failed=1
+                else
+                  echo "  $name $version"
+                fi
+                ;;
+              # Not an error. `blobatar-codemod` is unscoped precisely so the
+              # library's version cannot drag it along, so it releases on its
+              # own and a `v*` tag is not its tag. Logged so that a package
+              # nobody meant to leave off the train is visible here.
+              *) echo "  (not in this release) $name $version" ;;
+            esac
+          done < <(bun scripts/publishable.ts)
+          [ "$failed" -eq 0 ]
+
+      # The hazard this exists for is a partial release, and it is specific to
+      # how these packages authenticate. A trusted publisher is registered on
+      # npmjs.com against a package that already exists — there is no package
+      # settings page for a name nobody has published — so a package's very
+      # first publish cannot come from this workflow. It needs one manual,
+      # token-authenticated publish, after which the trusted publisher can be
+      # registered and every release after it is OIDC.
+      #
+      # Without this check that failure lands *during* the publish loop, after
+      # some of the lockstep group is already on the registry and cannot be
+      # unpublished after 72 hours. Checking first turns an unrecoverable
+      # partial release into a run that never started.
+      #
+      # npm's own documentation states neither the requirement nor its absence,
+      # so this is written against observed behaviour rather than a spec. If npm
+      # later allows a first publish over OIDC, this step costs one `npm view`
+      # per package and can be deleted.
+      - name: Every package must already exist for OIDC to work
+        run: |
+          missing=""
+          while IFS=$'\t' read -r name version group; do
+            [ "$group" = "lockstep" ] || continue
+            if npm view "$name" version >/dev/null 2>&1; then
+              echo "  $name is on the registry"
+            else
+              missing="$missing $name"
+            fi
+          done < <(bun scripts/publishable.ts)
+          if [ -n "$missing" ]; then
+            echo "::error::never published, so no trusted publisher can exist yet:$missing"
+            echo "Publish each one manually once, with a token, then register its"
+            echo "trusted publisher (this repo, workflow filename release.yml) and"
+            echo "re-run this tag. Nothing was published by this run."
             exit 1
           fi
-        if: github.event_name == 'push'
 
       # npm, not bun: `bun publish` does not yet emit provenance attestations.
       #
-      # No NODE_AUTH_TOKEN. The package is published through npm's trusted
-      # publisher for this repo and this workflow file, so the credential is the
-      # OIDC token `id-token: write` above mints — there is no long-lived npm
-      # token in this repo to leak or rotate. Renaming this file breaks the
-      # trust: the publisher is registered against `release.yml` by name.
+      # No NODE_AUTH_TOKEN. Each package is published through its own npm
+      # trusted publisher for this repo and this workflow file, so the
+      # credential is the OIDC token `id-token: write` above mints — there is no
+      # long-lived npm token in this repo to leak or rotate.
+      #
+      # Renaming this file breaks the trust, and that warning now applies once
+      # per package rather than once: the publisher is registered against
+      # `release.yml` by name, separately for `blobatar`, `@blobatar/react` and
+      # `@blobatar/vue`, and for every adapter added after them.
+      #
+      # One `npm publish` per package rather than one command, so a failure
+      # names the package it happened to, and so the loop cannot be widened by
+      # accident into publishing something the tag gate never checked.
+      # Skipping a version already on the registry is what makes a re-run safe.
+      # The 72-hour rule means a release that dies halfway cannot be undone and
+      # can only be finished, so the recovery path has to be "push the tag
+      # again" — and that only works if publishing is idempotent. It is also the
+      # step that lets a package be bootstrapped by hand (see the check above)
+      # and then rejoin this workflow without the next tag failing on it.
+      #
+      # Safe to skip rather than fail because the gate above has already
+      # asserted that every version here equals the tag: a package that is
+      # already at this version is one this same release published, not a
+      # different build wearing the same number.
       - name: Publish
-        run: npm publish --workspace blobatar --provenance --access public
+        run: |
+          while IFS=$'\t' read -r name version group; do
+            [ "$group" = "lockstep" ] || continue
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "  $name@$version is already published — skipping"
+              continue
+            fi
+            echo "::group::npm publish $name@$version"
+            npm publish --workspace "$name" --provenance --access public
+            echo "::endgroup::"
+          done < <(bun scripts/publishable.ts)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,18 @@ jobs:
       # unpublished after 72 hours. Checking first turns an unrecoverable
       # partial release into a run that never started.
       #
-      # npm's own documentation states neither the requirement nor its absence,
-      # so this is written against observed behaviour rather than a spec. If npm
-      # later allows a first publish over OIDC, this step costs one `npm view`
-      # per package and can be deleted.
+      # npm's own documentation states neither the requirement nor its absence.
+      # The citation is npm/cli#8544, where a maintainer says first publish was
+      # left out deliberately — "we determined to not have 'first publish'
+      # available to limit scope in our MVP, but are evaluating options for the
+      # next step". Open as of August 2026, so a token is still the only way a
+      # package comes into existence. The community workaround is a throwaway
+      # version published with a token, which is the same token and one more
+      # version on the registry, so this repo does the honest thing and
+      # bootstraps at the real version.
+      #
+      # If that issue closes, this step costs one `npm view` per package and can
+      # be deleted along with the whole bootstrap.
       - name: Every package must already exist for OIDC to work
         run: |
           missing=""

--- a/scripts/publishable.ts
+++ b/scripts/publishable.ts
@@ -1,0 +1,77 @@
+/**
+ * Which packages a release publishes, derived rather than listed.
+ *
+ * `release.yml` needs three things that a hand-written list in YAML would let
+ * drift apart: what to publish, what the tag must agree with, and what is
+ * deliberately not on this release train. All three follow from facts already
+ * stated elsewhere — `private` in each manifest, and the `fixed` group in
+ * `.changeset/config.json` — so they are read from there instead.
+ *
+ * ## Why not `npm publish --workspaces`
+ *
+ * Because it is wrong here, and quietly. `--workspaces` publishes every
+ * non-private workspace member, which includes `blobatar-codemod` — and the
+ * codemod is unscoped precisely so the `fixed` group cannot drag it to the
+ * library's version (see its `"//name"`). It sits at 0.1.0 while the library is
+ * at 2.x, so a library release would attempt to republish an unchanged 0.1.0
+ * and take the whole run down with EPUBLISHCONFLICT, *after* having already
+ * published some of the lockstep set. A partial publish of a lockstep group is
+ * the one outcome this pipeline must not produce.
+ *
+ * So the release publishes the lockstep group explicitly, and anything
+ * publishable outside it is reported rather than ignored — a new package that
+ * belongs on the train and is not on it should be visible in the log, not
+ * discovered when someone cannot install it.
+ */
+
+import { readdirSync } from "node:fs";
+
+type Manifest = { name?: string; version?: string; private?: boolean };
+
+const config = (await Bun.file(".changeset/config.json").json()) as {
+  fixed?: string[][];
+};
+
+/**
+ * The lockstep group, as changesets understands it. Read from `fixed` rather
+ * than restated, because these must be the same set: `fixed` is what keeps the
+ * *published* versions in step, and this is what decides which packages a tag
+ * publishes. Two lists would eventually disagree, and the failure would be a
+ * package silently left behind at the old version.
+ */
+const FIXED: string[] = config.fixed?.[0] ?? [];
+
+/** `@blobatar/*`-style globs only — one trailing `*`, no other wildcards. */
+const inLockstep = (name: string) =>
+  FIXED.some((pattern) =>
+    pattern.endsWith("*") ? name.startsWith(pattern.slice(0, -1)) : name === pattern,
+  );
+
+const members: { name: string; version: string; dir: string; lockstep: boolean }[] = [];
+
+for (const dir of readdirSync("packages")) {
+  const path = `packages/${dir}/package.json`;
+  const file = Bun.file(path);
+  if (!(await file.exists())) continue;
+
+  const manifest = (await file.json()) as Manifest;
+  // `private` is the only thing that decides publishability, and it is npm's
+  // own rule rather than a convention this file invents. `packages/harness`
+  // is the member it excludes today.
+  if (manifest.private || !manifest.name || !manifest.version) continue;
+
+  members.push({
+    name: manifest.name,
+    version: manifest.version,
+    dir,
+    lockstep: inLockstep(manifest.name),
+  });
+}
+
+members.sort((a, b) => a.name.localeCompare(b.name));
+
+// Tab-separated, because the consumer is a bash `while read` loop and the
+// alternative is asking a shell to parse JSON.
+for (const m of members) {
+  console.log([m.name, m.version, m.lockstep ? "lockstep" : "independent"].join("\t"));
+}


### PR DESCRIPTION
Fourth of five PRs in the package split ([plan](https://claude.ai/code/artifact/a52ed138-b0ea-4a07-aea4-853ed49f5173)). Independent of #13 — different files, either order.

`release.yml` published core and only core. Every gate in it was `bun --filter blobatar`, and the publish step named one package. This makes it release the lockstep group.

## The plan's one-line change was wrong

The plan said `npm publish --workspace blobatar` becomes `--workspaces`. That publishes every non-private workspace member, which includes `blobatar-codemod` — and the codemod is unscoped *precisely* so the `fixed` group cannot drag it to the library's version (its own `"//name"` says so). It sits at 0.1.0 while the library is at 2.x, so a library release would try to republish an unchanged 0.1.0 and die on `EPUBLISHCONFLICT` — **after** having already published some of the lockstep set.

A partial publish of a lockstep group is the one outcome this pipeline must not produce, and npm versions cannot be unpublished after 72 hours. So the release publishes the lockstep group explicitly.

`scripts/publishable.ts` derives that set rather than listing it: `private` decides publishability (npm's own rule, and what excludes the harness), and the `fixed` group in `.changeset/config.json` decides lockstep membership. Two hand-maintained lists would eventually disagree, and the failure mode is a package silently left behind at the old version.

```
@blobatar/react  2.1.0  lockstep
@blobatar/vue    2.1.0  lockstep
blobatar         2.1.0  lockstep
blobatar-codemod 0.1.0  independent
```

The codemod is logged as "not in this release" rather than ignored, so a package nobody meant to leave off the train is visible in the run.

## The tag gate now proves lockstep held

It asserted core's `package.json` against the tag. It now asserts every lockstep package, which makes it the check the plan wanted: `changeset version` bumps the group together, so a package disagreeing with the tag means the release commit is not what it appears to be and the adapters would publish pinned to a core major that is not shipping.

Verified against both failure modes — a tag ahead of the tree, and one package left behind at `2.0.0` while the others moved. The second names the drifting package rather than just failing.

## The unresolved npm question, answered as far as it can be

The plan flagged this as never verified: does trusted publishing require a package to exist before it can be registered?

**npm's own documentation states neither the requirement nor its absence.** It only says "navigate to your package settings on npmjs.com" — which presumes a package that exists — and the GA announcement says nothing about first publishes. Independent 2026 walkthroughs are consistent that the first publish must be token-authenticated. So the historical rule appears to still hold, and it is still undocumented.

Rather than plan around a maybe, the workflow checks the thing that actually matters and fails **before** publishing anything:

```
blobatar is on the registry
::error::never published, so no trusted publisher can exist yet: @blobatar/react @blobatar/vue
```

That is a real run against the live registry, and it confirms the bootstrap is genuinely outstanding: `blobatar` exists, neither adapter does. Without this step that failure lands mid-loop, after part of the group is on the registry and permanently so. With it, the run never starts. If npm later allows an OIDC first publish, the step costs one `npm view` per package and can be deleted.

## Publishing is idempotent

Because a release that dies halfway cannot be undone, only finished — so the recovery path has to be "push the tag again", and that only works if publishing skips what is already there. Dry-run against the live registry:

```
would publish @blobatar/react@2.1.0
would publish @blobatar/vue@2.1.0
blobatar@2.1.0 already published — skipping
```

Safe to skip rather than fail because the tag gate has already asserted every version equals the tag: a package already at this version is one this release published, not a different build wearing the same number. It is also what lets a hand-bootstrapped package rejoin the workflow without the next tag failing on it.

## Gates now match CI

Typecheck, tests, size and smoke all ran `--filter blobatar`, which was complete while core was the only published package and is now a release that never typechecks, tests or measures the adapters it is about to publish. All four run through turbo unfiltered.

`probe` is deliberately not among them: it drives real browsers this runner does not install, and it warns and exits 0 when it finds none. A gate that cannot fail is worse than an absent one.

## Not in this PR

- **The bootstrap itself.** Two packages need one manual token-authenticated publish and a trusted-publisher registration each, against this repo and the filename `release.yml`. The "renaming this file breaks the trust" warning now applies once per package.
- **A release channel for `blobatar-codemod`.** It is publishable, outside lockstep, and a `v*` tag is not its tag — so today nothing publishes it. That needs its own trigger (`codemod-v*`) and is a decision, not a mechanical change.
