### PR TITLE
fix: build the adapters when packing them

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "build": "bun scripts/build.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "check": "bun run typecheck"
+    "check": "bun run typecheck",
+    "//prepack": "This does not contradict `//check` below, and the difference is who owns the build. Under `check`, turbo owns it: the `build` task runs once for the whole workspace before any check reads a `dist`, so a check that rebuilt its own package would delete one out from under a concurrent check in another. Under `npm pack` and `npm publish` there is no turbo and no ordering — npm runs one lifecycle in one package — so without this the tarball is whatever `dist` happened to be on disk, which for a package built from a peer dependency can be stale, from another branch, or absent entirely. Core carried this from the start; the adapters were published by hand once without it, and only a manual `npm pack --dry-run` caught that the contents were right.",
+    "prepack": "bun run build"
   },
   "//peerDependencies": "`blobatar` is pinned to an exact major, not `^3`. Every package in this set publishes the same version (`.changeset/config.json`), and npm does not enforce that at install time — without the exact range, `@blobatar/react@4` resolves happily alongside `blobatar@3` and renders a different generation's faces from a package the consumer believes is current. Under ADR-0008 the major names the generation, so a mixed pair is not a version skew, it is the wrong picture. `packages/harness` asserts this range rather than trusting it, because release tooling rewrites workspace ranges and would quietly turn it into a caret.",
   "peerDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "build": "bun scripts/build.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "check": "bun run typecheck"
+    "check": "bun run typecheck",
+    "//prepack": "This does not contradict `//check` below, and the difference is who owns the build. Under `check`, turbo owns it: the `build` task runs once for the whole workspace before any check reads a `dist`, so a check that rebuilt its own package would delete one out from under a concurrent check in another. Under `npm pack` and `npm publish` there is no turbo and no ordering — npm runs one lifecycle in one package — so without this the tarball is whatever `dist` happened to be on disk, which for a package built from a peer dependency can be stale, from another branch, or absent entirely. Core carried this from the start; the adapters were published by hand once without it, and only a manual `npm pack --dry-run` caught that the contents were right.",
+    "prepack": "bun run build"
   },
   "//peerDependencies": "`blobatar` is pinned to an exact major, not `^3`. Every package in this set publishes the same version (`.changeset/config.json`), and npm does not enforce that at install time — without the exact range, `@blobatar/react@4` resolves happily alongside `blobatar@3` and renders a different generation's faces from a package the consumer believes is current. Under ADR-0008 the major names the generation, so a mixed pair is not a version skew, it is the wrong picture. `packages/harness` asserts this range rather than trusting it, because release tooling rewrites workspace ranges and would quietly turn it into a caret.",
   "peerDependencies": {


### PR DESCRIPTION
`blobatar` has had `"prepack": "bun run build"` from the start. The adapters never did, so `npm pack` and `npm publish` shipped whatever `dist` happened to be sitting on disk.

This is not theoretical. Delete `dist` and pack `@blobatar/vue` as it stands on `main` today:

```
npm notice 1.1kB LICENSE
npm notice 1.8kB README.md
npm notice 2.1kB package.json
npm notice 2.7kB src/index.ts
npm notice total files: 4
```

Four files, no `dist`, and `main` points at `./dist/index.js`. That is a completely broken package, and every other gate in the repo passes on it — the size gates read `dist` from the workspace, the harness resolves the workspace copy, and CI's `Pack` step only asserts that packing succeeds, which it does.

With `prepack`, the same command rebuilds first and produces the 8-file tarball. Both adapters verified from a deleted `dist`.

## Why this nearly shipped

The 2.2.0 release published both adapters by hand, because a package cannot be created over OIDC (npm/cli#8544). Nothing in that path builds. It came out correct only because the tarballs were inspected with `npm pack --dry-run` before publishing — a manual step that happened to be taken, not a gate.

PR 5 adds three more adapters, each needing the same manual bootstrap publish. Three more chances for the same mistake, which is why this is worth fixing now rather than after.

## It does not contradict the `//check` note

Both adapters carry a `"//check"` explaining that `check` must **not** run a build:

> No `bun run build` here. The build is a turbo task that `check` depends on, so it runs once for the whole workspace before any check reads a `dist` — a check that rebuilt its own package would delete `dist` out from under a concurrent check in another one.

That is still true, and the difference is who owns the build. Under `check`, turbo does: one build for the workspace, ordered before anything reads a `dist`. Under `npm pack` there is no turbo and no ordering — npm runs one lifecycle script in one package — so the build has to be stated locally or it does not happen. A `//prepack` note next to it says exactly this, because the two lines look contradictory to anyone reading only one.

## No changeset

`prepack` runs from the working tree at publish time, not from the installed package, so it protects the very next release without needing to ship first. Nothing observable to a consumer changes.

`blobatar-codemod` has the same gap and is deliberately not touched here — it is outside lockstep, has no release channel yet at all, and folding it in would mix two unrelated fixes.
