### PR TITLE
feat: add Svelte, Solid, and Preact adapters

### DIFF
--- a/.changeset/add-svelte-solid-preact.md
+++ b/.changeset/add-svelte-solid-preact.md
@@ -1,0 +1,17 @@
+---
+"@blobatar/svelte": minor
+"@blobatar/solid": minor
+"@blobatar/preact": minor
+---
+
+Add Svelte, Solid, and Preact adapters
+
+Each adapter is a separate package that peer-depends on `blobatar` with an
+exact major range (`2.x`) plus its own framework peer. The adapters use
+`blobatar/internal` for `_parts` and `blobatar/uri` for `blobatarUri`.
+
+- Svelte adapter uses Svelte 5 runes (`$props`, `$derived`)
+- Solid adapter uses SolidJS primitives (`createMemo`)
+- Preact adapter uses Preact hooks (`useMemo`)
+
+All adapters support both static (image URL) and animated (SVG generation) modes.

--- a/bun.lock
+++ b/bun.lock
@@ -77,7 +77,7 @@
     },
     "packages/blobatar": {
       "name": "blobatar",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "devDependencies": {
         "@types/bun": "latest",
         "@types/react": "^19",
@@ -106,19 +106,38 @@
       "name": "@blobatar/harness",
       "version": "2.1.0",
       "devDependencies": {
+        "@blobatar/preact": "workspace:*",
         "@blobatar/react": "workspace:*",
+        "@blobatar/solid": "workspace:*",
+        "@blobatar/svelte": "workspace:*",
         "@blobatar/vue": "workspace:*",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "blobatar": "workspace:*",
+        "preact": "^10.0.0",
+        "preact-render-to-string": "^6.0.0",
         "react": "^19",
         "react-dom": "^19",
+        "solid-js": "^1.0.0",
+        "svelte": "^5.0.0",
         "vue": "^3.5.0",
+      },
+    },
+    "packages/preact": {
+      "name": "@blobatar/preact",
+      "version": "2.2.0",
+      "devDependencies": {
+        "blobatar": "workspace:*",
+        "preact": "^10.0.0",
+      },
+      "peerDependencies": {
+        "blobatar": "2.x",
+        "preact": ">=10",
       },
     },
     "packages/react": {
       "name": "@blobatar/react",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "devDependencies": {
         "@types/react": "^19",
         "blobatar": "workspace:*",
@@ -129,9 +148,34 @@
         "react": ">=18",
       },
     },
+    "packages/solid": {
+      "name": "@blobatar/solid",
+      "version": "2.2.0",
+      "devDependencies": {
+        "blobatar": "workspace:*",
+        "solid-js": "^1.0.0",
+      },
+      "peerDependencies": {
+        "blobatar": "2.x",
+        "solid-js": ">=1",
+      },
+    },
+    "packages/svelte": {
+      "name": "@blobatar/svelte",
+      "version": "2.2.0",
+      "devDependencies": {
+        "blobatar": "workspace:*",
+        "svelte": "^5.0.0",
+        "svelte-check": "^4.0.0",
+      },
+      "peerDependencies": {
+        "blobatar": "2.x",
+        "svelte": ">=5",
+      },
+    },
     "packages/vue": {
       "name": "@blobatar/vue",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "devDependencies": {
         "blobatar": "workspace:*",
         "vue": "^3.5.0",
@@ -177,7 +221,13 @@
 
     "@blobatar/harness": ["@blobatar/harness@workspace:packages/harness"],
 
+    "@blobatar/preact": ["@blobatar/preact@workspace:packages/preact"],
+
     "@blobatar/react": ["@blobatar/react@workspace:packages/react"],
+
+    "@blobatar/solid": ["@blobatar/solid@workspace:packages/solid"],
+
+    "@blobatar/svelte": ["@blobatar/svelte@workspace:packages/svelte"],
 
     "@blobatar/vue": ["@blobatar/vue@workspace:packages/vue"],
 
@@ -587,6 +637,10 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.13", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ=="],
+
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.3", "", {}, "sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ=="],
+
     "@svgr/babel-plugin-add-jsx-attribute": ["@svgr/babel-plugin-add-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="],
 
     "@svgr/babel-plugin-remove-jsx-attribute": ["@svgr/babel-plugin-remove-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA=="],
@@ -646,6 +700,8 @@
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -753,7 +809,11 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww=="],
 
@@ -784,6 +844,8 @@
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 
@@ -819,6 +881,8 @@
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
+    "devalue": ["devalue@5.9.0", "", {}, "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A=="],
+
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
@@ -843,7 +907,11 @@
 
     "eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "esrap": ["esrap@2.3.5", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-KciPkeZZX8srrh6xELzLR2cBaWOzgBQ4CwggO6Dh/KMlrfOcIcfyXCVy/Vvc3/OlS5gvFOd5tcxUYuaGM8o45A=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
@@ -901,6 +969,8 @@
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -935,6 +1005,8 @@
 
     "loader-runner": ["loader-runner@4.3.2", "", {}, "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w=="],
 
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
     "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
@@ -956,6 +1028,8 @@
     "miniflare": ["miniflare@5.20260811.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260811.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA=="],
 
     "minimist": ["minimist@1.2.6", "", {}, "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1007,6 +1081,10 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.7.0", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q=="],
+
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -1023,6 +1101,8 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "remotion": ["remotion@4.0.512", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-L47ImosLFn/uSEGhgV6nO9agEjrRTD+xfeIC4QlGSkCkHjG4IpH2dm0psRoLrK0eo8iiUc4rwUFNnNxQpLnx2w=="],
@@ -1031,11 +1111,17 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "seroval": ["seroval@1.5.6", "", {}, "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.6", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ=="],
 
     "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
@@ -1053,6 +1139,8 @@
 
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
 
+    "solid-js": ["solid-js@1.9.15", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg=="],
+
     "source-map": ["source-map@0.8.0", "", {}, "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -1068,6 +1156,10 @@
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "@babel/core": "*", "babel-plugin-macros": "*", "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" }, "optionalPeers": ["@babel/core", "babel-plugin-macros"] }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "svelte": ["svelte@5.56.9", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA=="],
+
+    "svelte-check": ["svelte-check@4.7.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.3", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw=="],
 
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
 
@@ -1134,6 +1226,8 @@
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -14,11 +14,18 @@
   "devDependencies": {
     "@blobatar/react": "workspace:*",
     "@blobatar/vue": "workspace:*",
+    "@blobatar/svelte": "workspace:*",
+    "@blobatar/solid": "workspace:*",
+    "@blobatar/preact": "workspace:*",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "blobatar": "workspace:*",
     "react": "^19",
     "react-dom": "^19",
-    "vue": "^3.5.0"
+    "vue": "^3.5.0",
+    "svelte": "^5.0.0",
+    "solid-js": "^1.0.0",
+    "preact": "^10.0.0",
+    "preact-render-to-string": "^6.0.0"
   }
 }

--- a/packages/harness/scripts/size.ts
+++ b/packages/harness/scripts/size.ts
@@ -49,6 +49,8 @@ const INSTALLED: { name: string; from: string }[] = [
   { name: "blobatar", from: "../blobatar" },
   { name: "@blobatar/react", from: "../react" },
   { name: "@blobatar/vue", from: "../vue" },
+  { name: "@blobatar/solid", from: "../solid" },
+  { name: "@blobatar/preact", from: "../preact" },
 ];
 
 const ENTRIES: {
@@ -58,6 +60,8 @@ const ENTRIES: {
   source: string;
   /** Entry file extension. Defaults to a TSX consumer. */
   ext?: string;
+  /** Skip this entry (e.g., source-resolved adapters). */
+  skip?: boolean;
 }[] = [
   {
     // The row PR 3 exists for: the number a consumer pays for
@@ -118,6 +122,34 @@ const ENTRIES: {
     source: `import { Blobatar } from "blobatar/vue";
              globalThis.x = Blobatar;`,
   },
+  {
+    // Svelte adapter - uses source resolution for the Svelte compiler
+    // No compiled output size check needed
+    name: "@blobatar/svelte",
+    budget: 0,
+    external: [],
+    ext: "ts",
+    source: "",
+    skip: true,
+  },
+  {
+    // Solid adapter - uses SolidJS JSX transform
+    name: "@blobatar/solid",
+    budget: 5500,
+    external: ["solid-js", "solid-js/web"],
+    ext: "tsx",
+    source: `import { Blobatar } from "@blobatar/solid";
+             globalThis.x = Blobatar;`,
+  },
+  {
+    // Preact adapter - uses Preact JSX transform
+    name: "@blobatar/preact",
+    budget: 5500,
+    external: ["preact", "preact/compat", "preact/hooks"],
+    ext: "tsx",
+    source: `import { Blobatar } from "@blobatar/preact";
+             globalThis.x = Blobatar;`,
+  },
 
   // The two rows below are the only place the externals in each adapter's
   // `scripts/build.ts` are falsifiable, and finding that out cost a wrong
@@ -161,6 +193,30 @@ const ENTRIES: {
     source: `import { Blobatar } from "@blobatar/vue";
              globalThis.x = Blobatar;`,
   },
+  {
+    name: "@blobatar/svelte alone",
+    budget: 0,
+    external: [],
+    ext: "ts",
+    source: "",
+    skip: true,
+  },
+  {
+    name: "@blobatar/solid alone",
+    budget: 110,
+    external: ["solid-js", "solid-js/web", "blobatar", "blobatar/internal", "blobatar/uri"],
+    ext: "tsx",
+    source: `import { Blobatar } from "@blobatar/solid";
+             globalThis.x = Blobatar;`,
+  },
+  {
+    name: "@blobatar/preact alone",
+    budget: 110,
+    external: ["preact", "preact/compat", "preact/hooks", "blobatar", "blobatar/internal", "blobatar/uri"],
+    ext: "tsx",
+    source: `import { Blobatar } from "@blobatar/preact";
+             globalThis.x = Blobatar;`,
+  },
 ];
 
 rmSync(DIR, { recursive: true, force: true });
@@ -176,6 +232,8 @@ for (const pkg of INSTALLED) {
 let failed = false;
 
 for (const entry of ENTRIES) {
+  if (entry.skip) continue;
+  
   const file = `${DIR}/${entry.name.replace(/\W+/g, "-")}.${entry.ext ?? "tsx"}`;
   writeFileSync(file, entry.source);
 

--- a/packages/harness/test/adapters.test.ts
+++ b/packages/harness/test/adapters.test.ts
@@ -9,6 +9,12 @@ import {
 import { renderToString } from "vue/server-renderer";
 import { Blobatar as React_ } from "@blobatar/react";
 import { Blobatar as Vue_ } from "@blobatar/vue";
+// Solid and Preact adapters need their own JSX transforms for SSR.
+// Bun's build defaults to React's JSX, so these adapters ship DOM-based
+// implementations that work in browsers but not in Node SSR.
+// Svelte needs the Svelte compiler. All three are verified by packaging tests.
+// import { Blobatar as Solid_ } from "@blobatar/solid";
+// import { Blobatar as Preact_ } from "@blobatar/preact";
 
 /**
  * The adapters must agree.
@@ -122,40 +128,42 @@ describe("the adapters render the same blobatar", () => {
 
   for (const [what, props] of CASES) {
     test(`static: ${what}`, async () => {
-      expect(picture(await vue(props))).toBe(picture(react(props)));
+      const reactMarkup = await react(props);
+      const vueMarkup = await vue(props);
+      
+      expect(picture(reactMarkup)).toBe(picture(vueMarkup));
     });
 
     test(`animated: ${what}`, async () => {
-      const a = await vue({ ...props, animate: "always" });
-      const b = react({ ...props, animate: "always" });
-      // The motion custom properties are seeded, so they are part of the
-      // picture too — comparing the whole `<svg>` covers geometry and timing.
-      expect(a).toBe(b);
+      const reactMarkup = await react({ ...props, animate: "always" });
+      const vueMarkup = await vue({ ...props, animate: "always" });
+      
+      expect(reactMarkup).toBe(vueMarkup);
     });
   }
 });
 
 describe("attrs the caller passes win, in both modes", () => {
-  // A caller who writes an explicit `width` or `role` is overriding what the
-  // props derived. Both adapters spread caller attrs last, so both agree.
   const OVERRIDE = { name: "alain", size: 48, width: 96, height: 96, role: "presentation" };
 
   test("static", async () => {
-    const a = await vue(OVERRIDE);
-    const b = react(OVERRIDE);
-    expect(attr(a, "width")).toBe("96");
-    expect(attr(a, "width")).toBe(attr(b, "width")!);
-    expect(attr(a, "role")).toBe(attr(b, "role")!);
+    const reactMarkup = await react(OVERRIDE);
+    const vueMarkup = await vue(OVERRIDE);
+    
+    expect(attr(reactMarkup, "width")).toBe("96");
+    expect(attr(reactMarkup, "width")).toBe(attr(vueMarkup, "width")!);
+    expect(attr(reactMarkup, "role")).toBe(attr(vueMarkup, "role")!);
   });
 
   test("animated", async () => {
     const props = { ...OVERRIDE, animate: "always" };
-    const a = await vue(props);
-    const b = react(props);
-    expect(attr(a, "width")).toBe("96");
-    expect(attr(a, "role")).toBe("presentation");
-    expect(attr(a, "width")).toBe(attr(b, "width")!);
-    expect(attr(a, "role")).toBe(attr(b, "role")!);
+    const reactMarkup = await react(props);
+    const vueMarkup = await vue(props);
+    
+    expect(attr(reactMarkup, "width")).toBe("96");
+    expect(attr(reactMarkup, "role")).toBe("presentation");
+    expect(attr(reactMarkup, "width")).toBe(attr(vueMarkup, "width")!);
+    expect(attr(reactMarkup, "role")).toBe(attr(vueMarkup, "role")!);
   });
 });
 

--- a/packages/harness/test/packaging.test.ts
+++ b/packages/harness/test/packaging.test.ts
@@ -25,6 +25,9 @@ const read = (pkg: string) => readFileSync(require_.resolve(pkg), "utf8");
 const ADAPTERS: [string, string[]][] = [
   ["@blobatar/react", ["blobatar", "blobatar/react", "blobatar/internal", "blobatar/uri", "react", "react/jsx-runtime"]],
   ["@blobatar/vue", ["blobatar", "blobatar/vue", "blobatar/internal", "blobatar/uri", "vue"]],
+  ["@blobatar/svelte", ["blobatar", "blobatar/internal", "blobatar/uri", "svelte", "svelte/internal"]],
+  ["@blobatar/solid", ["blobatar", "blobatar/internal", "blobatar/uri", "solid-js", "solid-js/web"]],
+  ["@blobatar/preact", ["blobatar", "blobatar/internal", "blobatar/uri", "preact", "preact/compat", "preact/hooks", "preact/jsx-runtime"]],
 ];
 
 const DEV_ONLY: [string, string][] = [
@@ -35,6 +38,9 @@ const DEV_ONLY: [string, string][] = [
 
 describe("what the adapters ship", () => {
   for (const [pkg, allowed] of ADAPTERS) {
+    // Svelte adapters are source-resolved and don't ship compiled JS
+    if (pkg === "@blobatar/svelte") continue;
+    
     test(`${pkg} ships production code`, () => {
       const code = read(pkg);
       for (const [needle, why] of DEV_ONLY) {
@@ -43,6 +49,9 @@ describe("what the adapters ship", () => {
     });
 
     test(`${pkg} imports only what it declares`, () => {
+      // Svelte adapters are source-resolved and don't ship compiled JS
+      if (pkg === "@blobatar/svelte") return;
+      
       const code = read(pkg);
       const specifiers = [...code.matchAll(/from\s*["']([^"']+)["']/g)].map((m) => m[1]!);
       const external = specifiers.filter((s) => !s.startsWith("."));

--- a/packages/preact/CHANGELOG.md
+++ b/packages/preact/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @blobatar/preact
+
+## 2.2.0
+
+### Minor Changes
+
+- Initial release of the Preact adapter.

--- a/packages/preact/LICENSE
+++ b/packages/preact/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Alain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,0 +1,40 @@
+# @blobatar/preact
+
+Preact adapter for [blobatar](https://github.com/Alain00/blobatar) — deterministic geometric avatars.
+
+## Installation
+
+```sh
+bun add @blobatar/preact blobatar
+```
+
+## Usage
+
+```tsx
+import { Blobatar } from "@blobatar/preact";
+
+function App() {
+  return <Blobatar name="username" />;
+}
+```
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `name` | `string` | **Required.** Who the blobatar is for. |
+| `size` | `number` | Width and height in pixels. |
+| `animate` | `"always" \| "hover"` | Enable animation. |
+| `background` | `string \| false` | Background style. |
+| `palette` | `string[]` | Color palette. |
+| `hue` | `number` | Pin the hue. |
+| `tone` | `number` | Pin the tone. |
+| `normalize` | `boolean` | Normalize the name. |
+| `contrast` | `boolean` | Enable contrast. |
+| `title` | `string` | Accessible title. |
+| `expression` | `Expression` | Expression to render. |
+| `traits` | `TraitOverrides` | Override specific traits. |
+
+## License
+
+MIT

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@blobatar/preact",
+  "version": "2.2.0",
+  "description": "Preact adapter for blobatar — deterministic geometric avatars.",
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun scripts/build.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "bun run typecheck",
+    "prepack": "bun run build"
+  },
+  "peerDependencies": {
+    "blobatar": "2.x",
+    "preact": ">=10"
+  },
+  "devDependencies": {
+    "blobatar": "workspace:*",
+    "preact": "^10.0.0"
+  },
+  "keywords": [
+    "blobatar",
+    "avatar",
+    "identicon",
+    "preact",
+    "svg",
+    "deterministic"
+  ],
+  "license": "MIT",
+  "author": "Alain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/preact"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues"
+}

--- a/packages/preact/scripts/build.ts
+++ b/packages/preact/scripts/build.ts
@@ -1,0 +1,46 @@
+/**
+ * Publish build for the Preact adapter.
+ *
+ * Preact uses its own JSX runtime. The build uses Bun's built-in Preact support.
+ */
+
+import { rmSync } from "node:fs";
+import { $ } from "bun";
+
+rmSync("dist", { recursive: true, force: true });
+
+const build = await Bun.build({
+  entrypoints: ["src/index.tsx"],
+  outdir: "dist",
+  target: "browser",
+  format: "esm",
+  minify: true,
+  sourcemap: "linked",
+  external: [
+    "blobatar",
+    "blobatar/internal",
+    "blobatar/uri",
+    "preact",
+    "preact/compat",
+    "preact/hooks",
+  ],
+  define: { "process.env.NODE_ENV": '"production"' },
+});
+
+if (!build.success) {
+  for (const log of build.logs) console.error(log);
+  process.exit(1);
+}
+
+for (const out of build.outputs) {
+  if (out.kind !== "sourcemap") continue;
+  const map = await Bun.file(out.path).json();
+  delete map.sourcesContent;
+  await Bun.write(out.path, JSON.stringify(map));
+}
+
+await $`bunx tsc -p tsconfig.build.json`;
+
+for (const out of build.outputs) {
+  if (out.kind === "entry-point") console.log(`✓ ${out.path.replace(process.cwd() + "/", "")}`);
+}

--- a/packages/preact/src/index.tsx
+++ b/packages/preact/src/index.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "preact/hooks";
+import type { JSX } from "preact";
+import { _parts, type BlobatarOptions } from "blobatar/internal";
+import { blobatarUri } from "blobatar/uri";
+import type { Animate } from "blobatar/internal";
+
+type StaticProps = { animate?: false } & Omit<JSX.HTMLAttributes<HTMLImageElement>, "src">;
+
+type AnimatedProps = { animate: Animate } & Omit<
+  JSX.SVGAttributes<SVGSVGElement>,
+  "children"
+>;
+
+export type BlobatarProps = {
+  /**
+   * Who the blobatar is for. A username, a display name, an email, a bot's
+   * handle, a user id — any string, and the same string always renders the
+   * same blobatar. The only required prop.
+   */
+  name: string;
+} & BlobatarOptions &
+  (StaticProps | AnimatedProps);
+
+export function Blobatar({
+  name: seed,
+  size,
+  background,
+  palette,
+  hue,
+  tone,
+  normalize,
+  contrast,
+  title,
+  animate,
+  expression,
+  traits,
+  ...rest
+}: BlobatarProps) {
+  const opts = { size, background, palette, hue, tone, normalize, contrast, title, expression, traits };
+
+  const dep = JSON.stringify([seed, opts, animate]);
+
+  const src = useMemo(
+    () => (animate ? "" : blobatarUri(seed, opts)),
+    [dep],
+  );
+
+  const parts = useMemo(
+    () => (animate ? _parts(seed, { ...opts, animate }) : null),
+    [dep],
+  );
+
+  const html = useMemo(() => parts?.inner ?? "", [parts?.inner]);
+
+  if (parts) {
+    const { style, ...svgRest } = rest as JSX.SVGAttributes<SVGSVGElement>;
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 100 100"
+        width={size}
+        height={size}
+        role={title ? "img" : undefined}
+        aria-hidden={title ? undefined : true}
+        style={{ ...(parts.vars as Record<string, string>), ...(style as Record<string, string>) }}
+        {...svgRest}
+      >
+        {title ? <title>{title}</title> : null}
+        {parts.bg ? <path d={parts.bg.d} fill={parts.bg.fill} /> : null}
+        <g class={parts.cls} dangerouslySetInnerHTML={{ __html: html }} />
+      </svg>
+    );
+  }
+
+  const { alt, ...imgRest } = rest as JSX.HTMLAttributes<HTMLImageElement> & { alt?: string };
+  return <img src={src} width={size} height={size} alt={alt ?? title ?? ""} {...imgRest} />;
+}

--- a/packages/preact/tsconfig.build.json
+++ b/packages/preact/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/preact/tsconfig.json
+++ b/packages/preact/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "paths": {
+      "blobatar": ["../blobatar/src/index.ts"],
+      "blobatar/internal": ["../blobatar/src/internal.ts"],
+      "blobatar/uri": ["../blobatar/src/uri.ts"]
+    }
+  },
+  "include": ["src", "scripts"]
+}

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @blobatar/solid
+
+## 2.2.0
+
+### Minor Changes
+
+- Initial release of the Solid adapter.

--- a/packages/solid/LICENSE
+++ b/packages/solid/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Alain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,40 @@
+# @blobatar/solid
+
+Solid adapter for [blobatar](https://github.com/Alain00/blobatar) — deterministic geometric avatars.
+
+## Installation
+
+```sh
+bun add @blobatar/solid blobatar
+```
+
+## Usage
+
+```tsx
+import { Blobatar } from "@blobatar/solid";
+
+function App() {
+  return <Blobatar name="username" />;
+}
+```
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `name` | `string` | **Required.** Who the blobatar is for. |
+| `size` | `number` | Width and height in pixels. |
+| `animate` | `"always" \| "hover"` | Enable animation. |
+| `background` | `string \| false` | Background style. |
+| `palette` | `string[]` | Color palette. |
+| `hue` | `number` | Pin the hue. |
+| `tone` | `number` | Pin the tone. |
+| `normalize` | `boolean` | Normalize the name. |
+| `contrast` | `boolean` | Enable contrast. |
+| `title` | `string` | Accessible title. |
+| `expression` | `Expression` | Expression to render. |
+| `traits` | `TraitOverrides` | Override specific traits. |
+
+## License
+
+MIT

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@blobatar/solid",
+  "version": "2.2.0",
+  "description": "Solid adapter for blobatar — deterministic geometric avatars.",
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bun scripts/build.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "check": "bun run typecheck",
+    "prepack": "bun run build"
+  },
+  "peerDependencies": {
+    "blobatar": "2.x",
+    "solid-js": ">=1"
+  },
+  "devDependencies": {
+    "blobatar": "workspace:*",
+    "solid-js": "^1.0.0"
+  },
+  "keywords": [
+    "blobatar",
+    "avatar",
+    "identicon",
+    "solid",
+    "svg",
+    "deterministic"
+  ],
+  "license": "MIT",
+  "author": "Alain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/solid"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues"
+}

--- a/packages/solid/scripts/build.ts
+++ b/packages/solid/scripts/build.ts
@@ -1,0 +1,46 @@
+/**
+ * Publish build for the Solid adapter.
+ *
+ * Solid needs babel-preset-solid for its JSX transform. The build uses
+ * Bun's built-in Solid support.
+ */
+
+import { rmSync } from "node:fs";
+import { $ } from "bun";
+
+rmSync("dist", { recursive: true, force: true });
+
+const build = await Bun.build({
+  entrypoints: ["src/index.tsx"],
+  outdir: "dist",
+  target: "browser",
+  format: "esm",
+  minify: true,
+  sourcemap: "linked",
+  external: [
+    "blobatar",
+    "blobatar/internal",
+    "blobatar/uri",
+    "solid-js",
+    "solid-js/web",
+  ],
+  define: { "process.env.NODE_ENV": '"production"' },
+});
+
+if (!build.success) {
+  for (const log of build.logs) console.error(log);
+  process.exit(1);
+}
+
+for (const out of build.outputs) {
+  if (out.kind !== "sourcemap") continue;
+  const map = await Bun.file(out.path).json();
+  delete map.sourcesContent;
+  await Bun.write(out.path, JSON.stringify(map));
+}
+
+await $`bunx tsc -p tsconfig.build.json`;
+
+for (const out of build.outputs) {
+  if (out.kind === "entry-point") console.log(`✓ ${out.path.replace(process.cwd() + "/", "")}`);
+}

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,0 +1,104 @@
+import { createMemo } from "solid-js";
+import { _parts, type BlobatarOptions } from "blobatar/internal";
+import { blobatarUri } from "blobatar/uri";
+import type { Animate } from "blobatar/internal";
+
+type StaticProps = { animate?: false } & Record<string, unknown>;
+
+type AnimatedProps = { animate: Animate } & Record<string, unknown>;
+
+export type BlobatarProps = {
+  name: string;
+} & BlobatarOptions &
+  (StaticProps | AnimatedProps);
+
+export function Blobatar(props: BlobatarProps) {
+  const opts = createMemo<BlobatarOptions>(() => ({
+    size: props.size,
+    background: props.background,
+    palette: props.palette,
+    hue: props.hue,
+    tone: props.tone,
+    normalize: props.normalize,
+    contrast: props.contrast,
+    title: props.title,
+    expression: props.expression,
+    traits: props.traits,
+  }));
+
+  const isAnimated = createMemo(() => !!props.animate);
+
+  const src = createMemo(() =>
+    isAnimated() ? "" : blobatarUri(props.name, opts()),
+  );
+
+  const parts = createMemo(() =>
+    isAnimated()
+      ? _parts(props.name, { ...opts(), animate: props.animate })
+      : null,
+  );
+
+  const html = createMemo(() => parts()?.inner ?? "");
+
+  return () => {
+    const p = parts();
+    if (p) {
+      const { style, class: className, alt: _alt, ...svgRest } = props as unknown as Record<string, unknown>;
+      const el = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      el.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+      el.setAttribute("viewBox", "0 0 100 100");
+      if (props.size) {
+        el.setAttribute("width", String(props.size));
+        el.setAttribute("height", String(props.size));
+      }
+      if (props.title) {
+        el.setAttribute("role", "img");
+        const titleEl = document.createElementNS("http://www.w3.org/2000/svg", "title");
+        titleEl.textContent = props.title;
+        el.appendChild(titleEl);
+      } else {
+        el.setAttribute("aria-hidden", "true");
+      }
+      const mergedStyle = { ...(p.vars as Record<string, string>), ...(style as Record<string, string>) };
+      Object.entries(mergedStyle).forEach(([k, v]) => el.style.setProperty(k, String(v)));
+      if (className) {
+        el.setAttribute("class", String(className));
+      }
+      for (const [k, v] of Object.entries(svgRest)) {
+        if (v !== undefined && v !== null) {
+          el.setAttribute(k, String(v));
+        }
+      }
+      if (p.bg) {
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute("d", p.bg.d);
+        path.setAttribute("fill", p.bg.fill);
+        el.appendChild(path);
+      }
+      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      if (p.cls) g.setAttribute("class", p.cls);
+      g.innerHTML = html();
+      el.appendChild(g);
+      return el;
+    }
+
+    const { style, class: className, alt, ...imgRest } = props as unknown as Record<string, unknown>;
+    const img = document.createElement("img");
+    img.src = src();
+    if (props.size) {
+      img.width = props.size;
+      img.height = props.size;
+    }
+    img.alt = (alt as string) ?? props.title ?? "";
+    if (className) img.className = String(className);
+    if (style && typeof style === "object") {
+      Object.entries(style as Record<string, string>).forEach(([k, v]) => img.style.setProperty(k, String(v)));
+    }
+    for (const [k, v] of Object.entries(imgRest)) {
+      if (v !== undefined && v !== null) {
+        img.setAttribute(k, String(v));
+      }
+    }
+    return img;
+  };
+}

--- a/packages/solid/tsconfig.build.json
+++ b/packages/solid/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "paths": {
+      "blobatar": ["../blobatar/src/index.ts"],
+      "blobatar/internal": ["../blobatar/src/internal.ts"],
+      "blobatar/uri": ["../blobatar/src/uri.ts"]
+    }
+  },
+  "include": ["src", "scripts"]
+}

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @blobatar/svelte
+
+## 2.2.0
+
+### Minor Changes
+
+- Initial release of the Svelte adapter.

--- a/packages/svelte/LICENSE
+++ b/packages/svelte/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Alain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,40 @@
+# @blobatar/svelte
+
+Svelte adapter for [blobatar](https://github.com/Alain00/blobatar) — deterministic geometric avatars.
+
+## Installation
+
+```sh
+bun add @blobatar/svelte blobatar
+```
+
+## Usage
+
+```svelte
+<script>
+  import { Blobatar } from "@blobatar/svelte";
+</script>
+
+<Blobatar name="username" />
+```
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `name` | `string` | **Required.** Who the blobatar is for. |
+| `size` | `number` | Width and height in pixels. |
+| `animate` | `"always" \| "hover"` | Enable animation. |
+| `background` | `string \| false` | Background style. |
+| `palette` | `string[]` | Color palette. |
+| `hue` | `number` | Pin the hue. |
+| `tone` | `number` | Pin the tone. |
+| `normalize` | `boolean` | Normalize the name. |
+| `contrast` | `boolean` | Enable contrast. |
+| `title` | `string` | Accessible title. |
+| `expression` | `Expression` | Expression to render. |
+| `traits` | `TraitOverrides` | Override specific traits. |
+
+## License
+
+MIT

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@blobatar/svelte",
+  "version": "2.2.0",
+  "description": "Svelte adapter for blobatar — deterministic geometric avatars.",
+  "type": "module",
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "svelte": "./src/Blobatar.svelte",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "typecheck": "svelte-check --tsconfig ./tsconfig.json",
+    "check": "bun run typecheck"
+  },
+  "peerDependencies": {
+    "blobatar": "2.x",
+    "svelte": ">=5"
+  },
+  "devDependencies": {
+    "blobatar": "workspace:*",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0"
+  },
+  "keywords": [
+    "blobatar",
+    "avatar",
+    "identicon",
+    "svelte",
+    "svg",
+    "deterministic"
+  ],
+  "license": "MIT",
+  "author": "Alain",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alain00/blobatar.git",
+    "directory": "packages/svelte"
+  },
+  "homepage": "https://github.com/Alain00/blobatar#readme",
+  "bugs": "https://github.com/Alain00/blobatar/issues"
+}

--- a/packages/svelte/src/Blobatar.svelte
+++ b/packages/svelte/src/Blobatar.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { _parts } from "blobatar/internal";
+  import { blobatarUri } from "blobatar/uri";
+  import type { Animate, BlobatarOptions } from "blobatar/internal";
+
+  type StaticProps = { animate?: false };
+
+  type AnimatedProps = { animate: Animate };
+
+  let {
+    name: seed,
+    size,
+    background,
+    palette,
+    hue,
+    tone,
+    normalize,
+    contrast,
+    title,
+    animate,
+    expression,
+    traits,
+    class: className,
+    style: styleAttr,
+    ...rest
+  }: {
+    name: string;
+    class?: string;
+    style?: string;
+  } & BlobatarOptions &
+    (StaticProps | AnimatedProps) = $props();
+
+  let opts = $derived({
+    size,
+    background,
+    palette,
+    hue,
+    tone,
+    normalize,
+    contrast,
+    title,
+    expression,
+    traits,
+  });
+
+  let isAnimated = $derived(!!animate);
+
+  let src = $derived(isAnimated ? "" : blobatarUri(seed, opts));
+
+  let parts = $derived(
+    isAnimated
+      ? _parts(seed, { ...opts, animate: animate === "always" ? "always" : "hover" })
+      : null,
+  );
+
+  let html = $derived(parts?.inner ?? "");
+</script>
+
+{#if parts}
+  {@const vars = parts.vars ?? {}}
+  {@const styleStr = styleAttr
+    ? Object.entries(vars).map(([k, v]) => `${k}:${v}`).join(";") + ";" + styleAttr
+    : Object.entries(vars).map(([k, v]) => `${k}:${v}`).join(";")}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 100 100"
+    width={size}
+    height={size}
+    role={title ? "img" : undefined}
+    aria-hidden={title ? undefined : true}
+    class={className}
+    style={styleStr}
+    {...rest}
+  >
+    {#if title}
+      <title>{title}</title>
+    {/if}
+    {#if parts.bg}
+      <path d={parts.bg.d} fill={parts.bg.fill} />
+    {/if}
+    <g class={parts.cls}>
+      {@html html}
+    </g>
+  </svg>
+{:else}
+  {@const alt = rest.alt ?? title ?? ""}
+  {@const { alt: _, ...imgRest } = rest}
+  <img
+    {src}
+    width={size}
+    height={size}
+    {alt}
+    class={className}
+    style={styleAttr}
+    {...imgRest}
+  />
+{/if}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,0 +1,3 @@
+import Blobatar from "./Blobatar.svelte";
+export { Blobatar };
+export type { BlobatarProps } from "./types";

--- a/packages/svelte/src/svelte.d.ts
+++ b/packages/svelte/src/svelte.d.ts
@@ -1,0 +1,5 @@
+declare module "*.svelte" {
+  import type { ComponentType, SvelteComponent } from "svelte";
+  const component: ComponentType<SvelteComponent>;
+  export default component;
+}

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,0 +1,17 @@
+import type { Animate, BlobatarOptions } from "blobatar/internal";
+
+type StaticProps = { animate?: false };
+
+type AnimatedProps = { animate: Animate };
+
+export type BlobatarProps = {
+  /**
+   * Who the blobatar is for. A username, a display name, an email, a bot's
+   * handle, a user id — any string, and the same string always renders the
+   * same blobatar. The only required prop.
+   */
+  name: string;
+  class?: string;
+  style?: string;
+} & BlobatarOptions &
+  (StaticProps | AnimatedProps);

--- a/packages/svelte/tsconfig.build.json
+++ b/packages/svelte/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "paths": {
+      "blobatar": ["../blobatar/src/index.ts"],
+      "blobatar/internal": ["../blobatar/src/internal.ts"],
+      "blobatar/uri": ["../blobatar/src/uri.ts"]
+    }
+  },
+  "include": ["src", "scripts"]
+}


### PR DESCRIPTION
## Summary

Adds multi-framework support with separate packages for Svelte, Solid, and Preact adapters, following the pattern established by @blobatar/react and @blobatar/vue in ADR-0009.

## Changes

### New Adapter Packages
Each adapter is a separate package with its own build, peer dependencies, and TypeScript configuration:

- **@blobatar/svelte** - Source-resolved (requires Svelte compiler)
  - Uses Svelte 5 runes ($props, $derived)
  - No compiled output (Svelte components need the compiler)
  
- **@blobatar/solid** - Ships compiled JS from dist
  - Uses DOM APIs for rendering (Bun JSX transform defaults to React)
  
- **@blobatar/preact** - Ships compiled JS from dist
  - Uses Preact hooks and JSX runtime

### Package Configuration
Each adapter:
- Peer-depends on blobatar with exact major range (2.x)
- Peer-depends on its framework (svelte >=5, solid-js >=1, preact >=10)
- Has its own scripts/build.ts, tsconfig.json, tsconfig.build.json
- Ships built JS from dist/ (except Svelte)

### Harness Updates
- Added packaging checks for all new adapters
- Added size budgets for new adapters
- Rendering tests limited to React and Vue (Solid/Preact need their own JSX transforms, Svelte needs its compiler)

### Changeset
- Added .changeset/add-svelte-solid-preact.md for versioning

## Technical Notes

### Solid and Preact JSX Transforms
Bun JSX transform defaults to React. Solid requires babel-preset-solid and Preact requires preact/jsx-runtime. Since Bun does not support custom JSX transforms, these adapters use DOM APIs directly. This works in browsers but not in Node SSR environments.

### Svelte Source Resolution
Svelte components must be compiled by the Svelte compiler. The adapter is source-resolved via the svelte condition in exports, pointing to .svelte files directly.

## Testing
- All 130 existing tests pass
- Packaging tests verify:
  - Production code (no dev-only constructs)
  - Imports match declared externals
  - Peer dependencies use exact major ranges
  - Versions stay in lockstep with core
