### PR TITLE
Write the site's snippets in every adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,43 @@ The same props and the same behavior as the React adapter. Anything not
 declared as a prop lands on the underlying element, so `class`, `style`, `alt`
 and the rest behave as you would expect.
 
+### Svelte
+
+```sh
+bun add blobatar @blobatar/svelte
+```
+
+```svelte
+<script>
+  import { Blobatar } from "@blobatar/svelte";
+</script>
+
+<Blobatar name="alain@example.com" size={48} />
+```
+
+Svelte 5 or newer. This package ships its component as source rather than as
+built JavaScript, because a `.svelte` file only becomes renderable code inside
+your own compiler — any toolchain that resolves the `svelte` export condition
+handles that with no configuration, and one that does not reports an unresolved
+import naming the package rather than handing your bundler a file it cannot
+execute. See [ADR-0010](./docs/adr/0010-svelte-ships-source.md).
+
+### Solid and Preact
+
+```sh
+bun add blobatar @blobatar/solid     # or @blobatar/preact
+```
+
+```tsx
+import { Blobatar } from "@blobatar/solid";
+
+<Blobatar name={user.email} size={48} />;
+```
+
+The React section with the import swapped, which is the whole difference — each
+is compiled by its own framework's JSX transform rather than re-using React's,
+so `solid-js` reactivity and Preact's runtime both behave as they should.
+
 ### Anywhere else
 
 `blobatar()` returns SVG markup as a string, and `blobatarUri()` wraps it in a
@@ -74,7 +111,7 @@ import { blobatar } from "blobatar/blob";
 
 ### Configuring
 
-Options are the same across the React, Vue and string APIs. `background`, `hue`
+Options are the same across every adapter and the string API. `background`, `hue`
 and `tone` cover the common cases; `traits` pins any individual axis as the 0–1
 position the hash would otherwise have produced:
 
@@ -106,7 +143,7 @@ import "blobatar/motion.css"; // required — nothing animates without it
 <Blobatar name={user.email} animate="hover" expression={happy} size={64} />;
 ```
 
-The same props work with `@blobatar/vue` — only the component import changes.
+The same props work in every adapter — only the component import changes.
 
 ### Coming from `blobatar/react` or `blobatar/vue`
 

--- a/apps/site/src/Editor.tsx
+++ b/apps/site/src/Editor.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/editor/axes";
 import { blobLayout, resolved } from "@/editor/resolved";
 import { snippet, type Api, type Motion } from "@/editor/snippet";
+import { Caret, FrameworkMenu } from "@/components/ui/framework-menu";
+import { installFor, isFramework, type Framework } from "@/frameworks";
 import { NAMES } from "@/names";
 import { cn } from "@/lib/utils";
 import { ExportMenu } from "@/components/editor/export";
@@ -49,7 +51,19 @@ export function Editor() {
   const [name, setName] = useState("alain00");
   const [pinned, setPinned] = useState<TraitOverrides>({});
   const [api, setApi] = useState<Api>("react");
+  /**
+   * Which framework the first tab stands for, held apart from `api`.
+   *
+   * The strip has three slots and five of its seven values live in the first
+   * one, so the tab needs a label even while you are on `string` or `http` —
+   * and going back to it should return the framework you were reading, not
+   * React. That is a second piece of state by necessity: `api` cannot remember
+   * a framework it is not currently set to.
+   */
+  const [framework, setFramework] = useState<Framework>("react");
   const [motion, setMotion] = useState<Motion>("hover");
+  /** Whether the framework list is open. Controlled — see `FrameworkMenu`. */
+  const [picking, setPicking] = useState(false);
 
   /**
    * Every trait's current position, pinned or hashed — the same reader the
@@ -130,6 +144,14 @@ export function Editor() {
   /** Of those, the ones the name still gets a say in. */
   const loose = narrowed(pinned);
   const code = snippet({ api, name, pinned, motion });
+
+  /*
+    `http` needs no install at all and says so by keeping the bare package: the
+    endpoint is the one call site here you can use without one, and the pill is
+    left in place rather than removed so the column does not change height when
+    you tab across it.
+  */
+  const installCommand = isFramework(api) ? installFor(api) : "bun add blobatar";
 
   return (
     /*
@@ -234,7 +256,39 @@ export function Editor() {
                 onValueChange={(v: string) => v && setApi(v as Api)}
                 aria-label="API"
               >
-                <SegmentedItem value="react">react</SegmentedItem>
+                {/*
+                  The first slot is a tab and a menu at once, which is the whole
+                  trick that keeps five adapters off a strip with room for
+                  three. Clicking it while another tab is active only selects it
+                  — you asked for the framework you can see, not for a list —
+                  and clicking it while it is already active opens the list,
+                  which is the only remaining thing the click could mean.
+                */}
+                <FrameworkMenu
+                  value={framework}
+                  onChange={next => {
+                    setFramework(next);
+                    setApi(next);
+                  }}
+                  open={picking}
+                  onOpenChange={setPicking}
+                >
+                  <SegmentedItem
+                    value={framework}
+                    onClick={() => {
+                      if (isFramework(api)) setPicking(open => !open);
+                    }}
+                    // `inline-flex` is this chip's, not the base's: every other
+                    // segment is a word, and only this one has a second thing
+                    // to sit beside it. Without it the caret is a separate
+                    // inline box that wraps under the label and makes one
+                    // segment taller than the strip it is in.
+                    className="inline-flex items-center gap-1.5 pr-2.5"
+                  >
+                    {framework}
+                    <Caret className={cn(picking && "rotate-180")} />
+                  </SegmentedItem>
+                </FrameworkMenu>
                 <SegmentedItem value="string">string</SegmentedItem>
                 <SegmentedItem value="http">http</SegmentedItem>
               </Segmented>
@@ -267,7 +321,14 @@ export function Editor() {
                 }`}
           </p>
 
-          <Install command="bun add blobatar" className="mt-2 self-start" />
+          {/*
+            Follows the tab, because the two are one instruction read in order:
+            install this, then paste that. An adapter is a second package and
+            core is its peer rather than its dependency, so the framework tabs
+            name both — a pill that said `bun add blobatar` under a Svelte
+            snippet is a paste that cannot resolve its own import.
+          */}
+          <Install command={installCommand} className="mt-2 self-start" />
         </div>
 
         {/*

--- a/apps/site/src/components/Hero.test.ts
+++ b/apps/site/src/components/Hero.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { idle, happy } from "blobatar/expression";
+import { snippet } from "./Hero";
+import { SHAPES } from "@/shapes";
+import { FRAMEWORKS, type Framework } from "@/frameworks";
+
+/**
+ * The hero's snippet is the landing page's whole argument — "this is four lines
+ * you can paste" — so it has the same correctness property the editor's does,
+ * and now the same reason to be checked across five flavors: one emitter serves
+ * all of them, which is exactly the shape that can be quietly wrong for four.
+ *
+ * What is *not* re-tested here is the spelling rules themselves. Those live in
+ * `@/frameworks` and are pinned by `src/editor/snippet.test.ts`; repeating them
+ * would be two tests failing for one cause.
+ */
+
+const IDLE = { name: "idle", value: idle } as const;
+const HAPPY = { name: "happy", value: happy } as const;
+const CLOUD = SHAPES.find(s => s.name === "cloud") ?? SHAPES[0]!;
+const IDS = FRAMEWORKS.map(f => f.id);
+
+/** The tuned case: every axis the hero has, turned on at once. */
+const tuned = (fw: Framework) =>
+  snippet(fw, "alain00", "squircle", 210, HAPPY, CLOUD);
+
+describe("the hero snippet", () => {
+  test("imports the adapter you are reading, in every framework", () => {
+    for (const id of IDS) {
+      expect(tuned(id)).toContain(`import { Blobatar } from "@blobatar/${id}";`);
+      for (const other of IDS.filter(o => o !== id))
+        expect(tuned(id)).not.toContain(`@blobatar/${other}`);
+    }
+  });
+
+  test("carries all four axes into every framework", () => {
+    for (const id of IDS) {
+      const code = tuned(id);
+      expect(code).toContain("alain00");
+      expect(code).toContain(String(CLOUD.at));
+      expect(code).toContain("squircle");
+      expect(code).toContain("210");
+      expect(code).toContain("happy");
+    }
+  });
+
+  test("the expression import is core's, never an adapter's", () => {
+    // An expression is a value from `blobatar/expression` in all five — the one
+    // import line that does not move with the framework.
+    for (const id of IDS)
+      expect(tuned(id)).toContain(`import { happy } from "blobatar/expression";`);
+  });
+
+  test("the silhouette note is a comment its flavor actually has", () => {
+    // `// shape: cloud` inside a Vue or Svelte template is text, and it renders
+    // — the paste would draw its own annotation beside the blobatar.
+    for (const id of ["vue", "svelte"] as Framework[]) {
+      const markup = tuned(id).slice(tuned(id).indexOf("</script>"));
+      expect(markup).toContain("<!-- shape: cloud -->");
+      expect(markup).not.toContain("// shape");
+    }
+    for (const id of ["react", "solid", "preact"] as Framework[])
+      expect(tuned(id)).toContain("// shape: cloud");
+  });
+
+  test("only what differs from the defaults is written down", () => {
+    // Nothing tuned is a name and a mode, in every framework. A snippet that
+    // restated every default would read as configuration you owe the library.
+    for (const id of IDS) {
+      const bare = snippet(id, "alain00", "none", null, IDLE, null);
+      expect(bare).not.toContain("traits");
+      expect(bare).not.toContain("background");
+      expect(bare).not.toContain("hue");
+      expect(bare).not.toContain("expression");
+      expect(bare).toContain("alain00");
+    }
+  });
+
+  test("an empty name falls back rather than emitting nothing", () => {
+    for (const id of IDS)
+      expect(snippet(id, "", "none", null, IDLE, null)).toContain("blobatar");
+  });
+});

--- a/apps/site/src/components/Hero.tsx
+++ b/apps/site/src/components/Hero.tsx
@@ -28,6 +28,17 @@ import {
 import { Snippet } from "@/components/ui/snippet";
 import { SHAPES, type ShapeOption } from "@/shapes";
 import { Install } from "@/components/ui/install";
+import { Caret, FrameworkMenu } from "@/components/ui/framework-menu";
+import {
+  attrExpr,
+  attrString,
+  close,
+  comment,
+  infoFor,
+  installFor,
+  wrap,
+  type Framework,
+} from "@/frameworks";
 import { EggMark, eggFor } from "@/eggs";
 import { cn } from "@/lib/utils";
 
@@ -127,16 +138,22 @@ function useWide() {
 }
 
 /**
- * JSX attribute strings are not JS strings — no backslash escapes — so a name
- * containing a quote cannot be written as `name="…"` at all. Fall through to an
- * expression container, where the JS literal `JSON.stringify` produces is
- * exactly right.
+ * The hero's generator, in whichever framework you are reading.
+ *
+ * Four axes rather than the editor's twenty, and otherwise the same job — so
+ * the spellings come from the same table (`@/frameworks`) rather than being
+ * decided again here. Two generators is a deliberate split; two answers to
+ * "how does Vue write a bound prop" would not be.
+ *
+ * Exported for `Hero.test.ts` and for nothing else. The editor's equivalent got
+ * a module of its own on the grounds that a generator inside a component is
+ * testable only by rendering one; that is true of a *private* one, and a named
+ * export is the cheaper half of the same fix. It stays here because its inputs
+ * — `Bg`, `Pose`, `Shape` — are this file's, and moving four types out to
+ * follow one function would be the larger change, not the smaller one.
  */
-function attr(value: string) {
-  return /["\\]/.test(value) ? `{${JSON.stringify(value)}}` : `"${value}"`;
-}
-
-function snippet(
+export function snippet(
+  fw: Framework,
   seed: string,
   bg: Bg,
   hue: number | null,
@@ -144,35 +161,38 @@ function snippet(
   shape: Shape | null,
 ) {
   const posed = pose.value !== idle;
+  const { pkg, flavor } = infoFor(fw);
 
-  const imports = [`import { Blobatar } from "@blobatar/react";`];
+  const imports = [`import { Blobatar } from "${pkg}";`];
+  // Expressions are values, not strings, and they are core's rather than any
+  // adapter's — so this import is the one line of the five that is identical in
+  // all five.
   if (posed) imports.push(`import { ${pose.name} } from "blobatar/expression";`);
   imports.push(`import "blobatar/motion.css";`);
 
   // Only what differs from the defaults. A snippet that restates every default
   // reads as configuration you are obliged to supply, which is the opposite of
   // what a one-prop library wants to advertise.
-  const props = [`name=${attr(seed || "blobatar")}`];
-  if (shape) props.push(`traits={{ shape: ${shape.at} }}`);
-  if (bg !== "none") props.push(`background="${bg}"`);
-  if (hue !== null) props.push(`hue={${hue}}`);
-  if (posed) props.push(`expression={${pose.name}}`);
-  props.push(`animate="hover"`);
+  const props = [attrString(flavor, "name", seed || "blobatar")];
+  if (shape) props.push(attrExpr(flavor, "traits", `{ shape: ${shape.at} }`));
+  if (bg !== "none") props.push(attrString(flavor, "background", bg));
+  if (hue !== null) props.push(attrExpr(flavor, "hue", String(hue)));
+  if (posed) props.push(attrExpr(flavor, "expression", pose.name));
+  props.push(attrString(flavor, "animate", "hover"));
 
   // The one line here that cannot be read off the code. `0.885` is a position in
   // a range, not a measurement, and nothing about it says "cloud" — so the name
-  // goes above the element, where a `//` is legal. Inside the attribute list it
-  // would not be: JSX has no line comments between props.
-  const note = shape ? [`// shape: ${shape.name}`] : [];
+  // goes above the element, where a comment is legal. Inside the attribute list
+  // it would not be: no flavor here has a line comment between props. Which
+  // comment it is belongs to the flavor — `//` renders as text in a template.
+  const note = shape ? [comment(flavor, `shape: ${shape.name}`)] : [];
 
-  return [
-    imports.join("\n"),
-    "",
+  return wrap(flavor, imports, [
     ...note,
     `<Blobatar`,
     ...props.map((p) => `  ${p}`),
-    `/>`,
-  ].join("\n");
+    close(flavor),
+  ]);
 }
 
 export function Hero() {
@@ -181,6 +201,19 @@ export function Hero() {
   const [hue, setHue] = useState<number | null>(null);
   const [pose, setPose] = useState<Pose>(POSES[0]);
   const [shape, setShape] = useState<Shape | null>(null);
+
+  /**
+   * Which adapter the snippet is written in.
+   *
+   * The hero's four axes are about the blobatar; this one is about you, and it
+   * is the only control here that changes no pixel of the preview. It earns its
+   * place anyway: the page's argument is "this is four lines you can paste",
+   * and that argument is only made to a React reader if the four lines are the
+   * only ones on offer.
+   */
+  const [fw, setFw] = useState<Framework>("react");
+  /** Whether the framework list is open. Controlled — see `FrameworkMenu`. */
+  const [picking, setPicking] = useState(false);
 
   /**
    * A reaction is a temporary override of the picked pose, not a replacement
@@ -710,14 +743,44 @@ export function Hero() {
           a command pill as wide as the snippet stops reading as a thing you
           press.
         */}
-        <Install command="bun add blobatar" className="self-start" />
+        <Install command={installFor(fw)} className="self-start" />
 
         <div className="flex flex-col gap-3">
-          <div className="text-muted flex items-baseline justify-between text-xs lowercase">
+          <div className="text-muted flex items-baseline justify-between gap-4 text-xs lowercase">
             <span>your config</span>
-            <span className="font-mono normal-case">Blobatar.tsx</span>
+            {/*
+              The picker sits with the filename rather than with the tuning
+              controls above, and that is the placement doing the explaining:
+              both of these describe the *file*, not the creature. The filename
+              follows the framework for the same reason — `.svelte` is how you
+              know the code below changed language.
+            */}
+            <span className="flex items-baseline gap-3">
+              <FrameworkMenu
+                value={fw}
+                onChange={setFw}
+                open={picking}
+                onOpenChange={setPicking}
+                align="end"
+              >
+                <button
+                  type="button"
+                  onClick={() => setPicking(open => !open)}
+                  aria-label={`Framework: ${fw}`}
+                  className={cn(
+                    "hover:text-ink flex items-center gap-1.5 rounded-full px-2 py-1",
+                    "hover:bg-raised/60 -mx-2 transition-colors duration-150",
+                    picking && "text-ink",
+                  )}
+                >
+                  {fw}
+                  <Caret className={cn(picking && "rotate-180")} />
+                </button>
+              </FrameworkMenu>
+              <span className="font-mono normal-case">{infoFor(fw).file}</span>
+            </span>
           </div>
-          <Snippet code={snippet(seed, bg, hue, pose, shape)} />
+          <Snippet code={snippet(fw, seed, bg, hue, pose, shape)} />
           <p className="text-muted text-xs leading-relaxed">
             Every prop is optional except the name. Drop{" "}
             <code className="font-mono">animate</code> and the blobatar renders as a

--- a/apps/site/src/components/ui/framework-menu.tsx
+++ b/apps/site/src/components/ui/framework-menu.tsx
@@ -1,0 +1,107 @@
+/**
+ * The framework picker, shared by the hero and the editor.
+ *
+ * Five adapters is where a flat strip stops working — the editor's would have
+ * become seven chips in a column narrow enough that they wrap — so the axis
+ * folds into a menu and the strip keeps its three slots. It is one component
+ * rather than two because the list is the part worth having in one place: a
+ * sixth adapter should appear on both pages by landing in `FRAMEWORKS`, not by
+ * being remembered twice.
+ *
+ * The trigger is the caller's, passed as `children` and rendered `asChild`,
+ * because the two pages disagree about what a trigger looks like there and
+ * neither is wrong: the editor's is a segment of a control strip, the hero's is
+ * a bare chip beside a filename. Only the panel is shared.
+ */
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { FRAMEWORKS, type Framework } from "@/frameworks";
+import { cn } from "@/lib/utils";
+
+export interface FrameworkMenuProps {
+  value: Framework;
+  onChange: (next: Framework) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The trigger, rendered as the popover's anchor. */
+  children: React.ReactNode;
+  align?: "start" | "center" | "end";
+}
+
+export function FrameworkMenu({
+  value,
+  onChange,
+  open,
+  onOpenChange,
+  children,
+  align = "start",
+}: FrameworkMenuProps) {
+  return (
+    /*
+      Controlled, and anchored rather than triggered. Both follow from the same
+      thing: on the editor the trigger is also a tab, so a click has two
+      meanings — select this framework, or, if it is already selected, open the
+      list. Radix's `Trigger` owns the click and would collapse those two into
+      one; an `Anchor` only positions, leaving the caller to decide which the
+      click was.
+    */
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverAnchor asChild>{children}</PopoverAnchor>
+      <PopoverContent align={align} sideOffset={8} className="w-40 p-1.5">
+        <div role="listbox" aria-label="Framework" className="flex flex-col">
+          {FRAMEWORKS.map(f => (
+            <button
+              key={f.id}
+              type="button"
+              role="option"
+              aria-selected={f.id === value}
+              onClick={() => {
+                onChange(f.id);
+                onOpenChange(false);
+              }}
+              className={cn(
+                "flex items-center justify-between rounded-xl px-3 py-2 text-left",
+                "text-xs lowercase transition-colors duration-150",
+                "hover:bg-line/60 hover:text-ink",
+                f.id === value ? "text-ink" : "text-muted",
+              )}
+            >
+              {f.id}
+              {/*
+                A dot rather than a checkmark. The row is already the selected
+                one by its weight; a tick is a second, louder claim about the
+                same fact, and this panel is 40px of a page whose subject is
+                somewhere else.
+              */}
+              {f.id === value ? (
+                <span aria-hidden="true" className="bg-ink size-1.5 rounded-full" />
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * The affordance on the trigger — a caret, and nothing else.
+ *
+ * Inline SVG rather than a glyph: `▾` is a character whose baseline and weight
+ * are the font's business, and it sits differently in every one of them.
+ */
+export function Caret({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 8 5"
+      className={cn("size-2 transition-transform duration-150", className)}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M1 1.25 4 4 7 1.25" />
+    </svg>
+  );
+}

--- a/apps/site/src/editor/snippet.test.ts
+++ b/apps/site/src/editor/snippet.test.ts
@@ -20,7 +20,10 @@ const snip = (input: SnippetInput) => snippet(input);
 
 /** The `traits` literal from a generated snippet, evaluated. */
 function pasted(code: string): Record<string, number | number[]> {
-  const body = code.match(/traits[=:]\s*\{\{?([\s\S]*?)\}\}?[,\n]/);
+  // The optional quotes are Vue's: its expression attributes wrap the literal in
+  // `"`, so the same object arrives one layer deeper than in JSX. Single-quoted
+  // keys inside it are still JS, which is all `new Function` needs.
+  const body = code.match(/traits[=:]\s*"?\{\{?([\s\S]*?)\}\}?"?[,\n]/);
   if (!body) return {};
   // `new Function` on our own generated string, in a test, is the point: it is
   // the closest thing to "paste this into a file" that a test can do, and it
@@ -115,11 +118,11 @@ describe("what it emits", () => {
   });
 
   test("the string API drops `animate` out loud rather than silently", () => {
-    // `blobatar()` returns static markup whatever it is passed — animation is a
-    // `@blobatar/react` option. Emitting it would be a snippet that lies.
+    // `blobatar()` returns static markup whatever it is passed — animation is
+    // an adapter option. Emitting it would be a snippet that lies.
     const code = snip({ api: "string", name: NAME, pinned: {}, motion: "always" });
     expect(code).not.toContain("animate:");
-    expect(code).toContain("// animate is a @blobatar/react option");
+    expect(code).toContain("// animate is a component option");
   });
 
   test("the endpoint spelling is a url, with the generation pinned", () => {
@@ -169,6 +172,118 @@ describe("what it emits", () => {
   test("an empty name falls back rather than emitting nothing", () => {
     const code = snip({ api: "react", name: "", pinned: {}, motion: false });
     expect(code).toContain(`name="blobatar"`);
+  });
+});
+
+/**
+ * Five adapters, one component.
+ *
+ * The generator emits them from one table rather than five functions, so what
+ * is worth testing is not each framework's happy path — it is the places the
+ * flavors genuinely disagree, because those are where a shared emitter can be
+ * quietly wrong for four of them. Each test below is a mistake this file caught
+ * while it was being written.
+ */
+describe("every adapter", () => {
+  const FRAMEWORKS: Api[] = ["react", "vue", "svelte", "solid", "preact"];
+
+  test("each imports its own package, and none imports another's", () => {
+    for (const api of FRAMEWORKS) {
+      const code = snip({ api, name: NAME, pinned: {}, motion: false });
+      expect(code).toContain(`import { Blobatar } from "@blobatar/${api}";`);
+      for (const other of FRAMEWORKS.filter(f => f !== api))
+        expect(code).not.toContain(`@blobatar/${other}`);
+    }
+  });
+
+  test("the name reaches every one of them", () => {
+    for (const api of FRAMEWORKS)
+      expect(snip({ api, name: NAME, pinned: {}, motion: false })).toContain(NAME);
+  });
+
+  test("the pinned traits survive the trip into every flavor", () => {
+    // The acceptance property, per framework: whatever the attribute syntax is,
+    // the object inside it is the map the preview rendered.
+    for (const api of FRAMEWORKS) {
+      const one = snip({ api, name: NAME, pinned: { shape: 0.965 }, motion: false });
+      expect(pasted(one)).toEqual({ shape: 0.965 });
+
+      const many = snip({
+        api,
+        name: NAME,
+        pinned: { shape: 0.14, "eye.gap": 0.8, hue: 0.2 },
+        motion: false,
+      });
+      expect(pasted(many)).toEqual({ shape: 0.14, "eye.gap": 0.8, hue: 0.2 });
+    }
+  });
+
+  test("the single-file formats wrap the element, and the JSX ones do not", () => {
+    const vue = snip({ api: "vue", name: NAME, pinned: {}, motion: false });
+    expect(vue).toContain("<script setup>");
+    expect(vue).toContain("<template>");
+
+    const svelte = snip({ api: "svelte", name: NAME, pinned: {}, motion: false });
+    expect(svelte).toContain("<script>");
+    // Svelte has no `<template>`: the markup is the module body.
+    expect(svelte).not.toContain("<template>");
+
+    for (const api of ["react", "solid", "preact"] as Api[]) {
+      const code = snip({ api, name: NAME, pinned: {}, motion: false });
+      expect(code).not.toContain("<script");
+      expect(code).not.toContain("<template>");
+    }
+  });
+
+  test("a note in markup position is a markup comment, never `//`", () => {
+    // The bug this exists for: `//` beside a JSX element is a comment, and the
+    // identical line inside a Vue or Svelte template is *text* — it renders.
+    // A snippet that pasted its own annotation onto the page beside the
+    // blobatar would be worse than one with no annotation at all.
+    for (const api of ["vue", "svelte"] as Api[]) {
+      const code = snip({ api, name: NAME, pinned: { shape: 0.14 }, motion: false });
+      const markup = code.slice(code.indexOf("</script>"));
+      expect(markup).toContain("<!-- everything below comes from the name");
+      expect(markup).not.toContain("//");
+    }
+  });
+
+  test("Vue binds expressions and quotes keys so the attribute survives", () => {
+    // A double-quoted key inside a double-quoted attribute closes it early and
+    // the template stops parsing there.
+    const code = snip({ api: "vue", name: NAME, pinned: { "eye.gap": 0.8 }, motion: false });
+    expect(code).toContain(`:traits="{ 'eye.gap': 0.8 }"`);
+    expect(code).not.toContain('"eye.gap"');
+  });
+
+  test("a name that cannot be written plainly is escaped the way its flavor escapes", () => {
+    const quoted = 'say "hi"';
+
+    // Vue's template is HTML, so the quote is an entity and the prop stays
+    // static. JSX and Svelte have no entity layer and fall through to an
+    // expression container instead.
+    expect(snip({ api: "vue", name: quoted, pinned: {}, motion: false })).toContain(
+      'name="say &quot;hi&quot;"',
+    );
+    for (const api of ["react", "svelte", "solid", "preact"] as Api[])
+      expect(snip({ api, name: quoted, pinned: {}, motion: false })).toContain(
+        'name={"say \\"hi\\""}',
+      );
+  });
+
+  test("only JSX carries a statement terminator", () => {
+    for (const api of ["react", "solid", "preact"] as Api[])
+      expect(snip({ api, name: NAME, pinned: {}, motion: false }).trimEnd()).toEndWith("/>;");
+    for (const api of ["vue", "svelte"] as Api[])
+      expect(snip({ api, name: NAME, pinned: {}, motion: false }).trimEnd()).not.toContain("/>;");
+  });
+
+  test("animating says so in every flavor, and imports the stylesheet", () => {
+    for (const api of FRAMEWORKS) {
+      const code = snip({ api, name: NAME, pinned: {}, motion: "hover" });
+      expect(code).toContain(`import "blobatar/motion.css"`);
+      expect(code).toContain(`animate="hover"`);
+    }
   });
 });
 

--- a/apps/site/src/editor/snippet.ts
+++ b/apps/site/src/editor/snippet.ts
@@ -11,13 +11,35 @@
  */
 import type { TraitOverrides } from "blobatar";
 import { KEY_ORDER } from "./axes";
+import {
+  attrExpr,
+  attrString,
+  close,
+  comment,
+  exprClose,
+  exprOpen,
+  infoFor,
+  objectKey,
+  wrap,
+  type Flavor,
+  type Framework,
+} from "@/frameworks";
 
-export type Api = "react" | "string" | "http";
+/**
+ * The call sites, which is what the tab strip is an axis over.
+ *
+ * Five of the seven are frameworks and differ only in package name and
+ * attribute spelling, so they are one member of this union expanded rather than
+ * five hand-written emitters — see `@/frameworks`. The other two are genuinely
+ * different APIs: `string` returns markup and `http` is a URL, and neither has
+ * a component to configure.
+ */
+export type Api = Framework | "string" | "http";
 export type Motion = false | "hover" | "always";
 
 export interface SnippetInput {
   api: Api;
-  /** The name the preview is showing. Emitted literally — see `nameNote`. */
+  /** The name the preview is showing. Emitted literally — see `NAME_NOTE`. */
   name: string;
   /** The pinned traits. Empty means no `traits` at all in the output. */
   pinned: TraitOverrides;
@@ -29,11 +51,11 @@ export interface SnippetInput {
  *
  * Quoting every key would be uniform and slightly uglier; both are defensible
  * and the rule is to pick one. This picks the one a person writing the object
- * by hand would produce, since looking hand-written is the whole brief.
+ * by hand would produce, since looking hand-written is the whole brief. Which
+ * quote character it reaches for is the flavor's call, not this module's —
+ * `objectKey` carries that, and the reason.
  */
-const bare = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-
-const key = (k: string) => (bare.test(k) ? k : JSON.stringify(k));
+const key = objectKey;
 
 /**
  * Panel order, then anything else.
@@ -62,15 +84,6 @@ const literal = (v: number | number[]) =>
   Array.isArray(v) ? `[${v.join(", ")}]` : String(v);
 
 /**
- * JSX attribute strings are not JS strings — no backslash escapes — so a name
- * containing a quote cannot be written as `name="…"` at all. Fall through to an
- * expression container, where the JS literal `JSON.stringify` produces is
- * exactly right. Same helper as the hero's, same reason.
- */
-const attr = (value: string) =>
-  /["\\]/.test(value) ? `{${JSON.stringify(value)}}` : `"${value}"`;
-
-/**
  * The name is emitted literally, and it has to be.
  *
  * A real call site says `name={user.email}`, and the temptation is to emit that
@@ -78,54 +91,71 @@ const attr = (value: string) =>
  * substitutes a variable for the string the preview used renders a different
  * blobatar. The literal is the honest output; the comment is what tells you
  * which half of it is yours to replace.
+ *
+ * Spelled by the flavor rather than written out, because it sits in markup
+ * position: see `comment`.
  */
-const nameNote = "// everything below comes from the name unless it is pinned";
+const NAME_NOTE = "everything below comes from the name unless it is pinned";
 
 export function snippet({ api, name, pinned, motion }: SnippetInput): string {
   const traits = entries(pinned);
   const seed = name || "blobatar";
 
-  return api === "react"
-    ? react(seed, traits, motion)
-    : api === "string"
-      ? string(seed, traits, motion)
-      : http(seed, traits, motion);
+  return api === "string"
+    ? string(seed, traits, motion)
+    : api === "http"
+      ? http(seed, traits, motion)
+      : component(api, seed, traits, motion);
 }
 
-function react(
+/**
+ * Any of the five adapters.
+ *
+ * One emitter rather than five because the adapters are one component with five
+ * publishers: the props are identical, so what a Svelte snippet and a Preact
+ * snippet disagree about is the package they import and how their template
+ * spells an attribute — both of which are table lookups. The alternative, five
+ * near-identical functions, is five places for a prop to be added to four of.
+ */
+function component(
+  id: Framework,
   seed: string,
   traits: (readonly [string, number | number[]])[],
   motion: Motion,
 ) {
-  const lines = [`import { Blobatar } from "@blobatar/react";`];
+  const { pkg, flavor } = infoFor(id);
+
+  const imports = [`import { Blobatar } from "${pkg}";`];
   // The trade the library documents, stated where it is taken rather than in
   // prose beside the box: animating is what moves the blobatar out of a single
   // `<img>` and into a dozen inline SVG nodes.
   if (motion)
-    lines.push(
+    imports.push(
       `import "blobatar/motion.css"; // animate renders inline SVG, not one <img>`,
     );
 
-  lines.push("");
-  if (traits.length) lines.push(nameNote);
+  const lines: string[] = [];
+  if (traits.length) lines.push(comment(flavor, NAME_NOTE));
 
-  lines.push(`<Blobatar`, `  name=${attr(seed)}`);
+  lines.push(`<Blobatar`, `  ${attrString(flavor, "name", seed)}`);
   // One key inline, several over lines. A person writing `{ shape: 0.14 }`
   // does not break it across four lines, and a person writing six of them does
   // not leave it on one.
   if (traits.length === 1) {
     const [k, v] = traits[0]!;
-    lines.push(`  traits={{ ${key(k)}: ${literal(v)} }}`);
+    lines.push(`  ${attrExpr(flavor, "traits", `{ ${key(flavor, k)}: ${literal(v)} }`)}`);
   } else if (traits.length) {
-    lines.push(`  traits={{`);
-    for (const [k, v] of traits) lines.push(`    ${key(k)}: ${literal(v)},`);
-    lines.push(`  }}`);
+    // The delimiters end up on different lines, so this takes the pair rather
+    // than `attrExpr`, which closes what it opens.
+    lines.push(`  ${exprOpen(flavor, "traits")}`);
+    for (const [k, v] of traits) lines.push(`    ${key(flavor, k)}: ${literal(v)},`);
+    lines.push(`  ${exprClose(flavor)}`);
   }
 
-  if (motion) lines.push(`  animate="${motion}"`);
-  lines.push(`/>;`);
+  if (motion) lines.push(`  ${attrString(flavor, "animate", motion)}`);
+  lines.push(close(flavor, true));
 
-  return lines.join("\n");
+  return wrap(flavor, imports, lines);
 }
 
 function string(
@@ -136,13 +166,14 @@ function string(
   const lines = [`import { blobatar } from "blobatar";`];
   lines.push("");
 
-  // `animate` is honored by `@blobatar/react` only — the string API returns
-  // static markup whatever it is passed. Dropping it silently on the way over
-  // would make this snippet a quieter blobatar than the one on screen, so it is
-  // dropped out loud.
+  // `animate` is honored by the adapters only — the string API returns static
+  // markup whatever it is passed. Dropping it silently on the way over would
+  // make this snippet a quieter blobatar than the one on screen, so it is
+  // dropped out loud. Named for the option rather than for one package: there
+  // are five adapters now, and the reader is on whichever tab they are on.
   if (motion)
-    lines.push(`// animate is a @blobatar/react option — this renders static markup`);
-  if (traits.length) lines.push(nameNote);
+    lines.push(`// animate is a component option — this renders static markup`);
+  if (traits.length) lines.push(`// ${NAME_NOTE}`);
 
   // Named `seed` here where the component takes `name`: same value, and the
   // words differ because they are read in different positions. See CONTEXT.md.
@@ -153,7 +184,9 @@ function string(
   lines.push(`${call}, {`);
   if (traits.length) {
     lines.push(`  traits: {`);
-    for (const [k, v] of traits) lines.push(`    ${key(k)}: ${literal(v)},`);
+    // Plain JS, so the JSX flavor's quoting is simply JS quoting — there is no
+    // template around this literal for a double quote to escape from.
+    for (const [k, v] of traits) lines.push(`    ${key("jsx", k)}: ${literal(v)},`);
     lines.push(`  },`);
   }
   lines.push(`});`);
@@ -233,7 +266,7 @@ function http(
     lines.push(`# no url spelling for ${unspellable.join(", ")} — from the name`);
   if (narrowed.length)
     lines.push(`# ${narrowed.join(", ")} narrowed — a url states one value, so this is from the name too`);
-  if (motion) lines.push(`# static svg — animate is a @blobatar/react option`);
+  if (motion) lines.push(`# static svg — animate is a component option`);
 
   lines.push(`${ENDPOINT}${encodeURIComponent(seed)}?${query.join("&")}`);
   return lines.join("\n");

--- a/apps/site/src/frameworks.ts
+++ b/apps/site/src/frameworks.ts
@@ -1,0 +1,190 @@
+/**
+ * The five adapters, as the two snippet generators need to know them.
+ *
+ * Shared rather than duplicated because there are two generators — the hero's
+ * four-axis one and the editor's — and a framework that exists in one but not
+ * the other is the exact drift this table prevents. It is also why the flavor
+ * is data here rather than a branch in each generator: adding a sixth adapter
+ * should be a row, not two new emitters.
+ *
+ * Deliberately small and free of editor imports. The hero is on the landing
+ * page, whose first paint the whole build is tuned around, and this module is
+ * what it pulls in to know that Svelte exists.
+ */
+
+/** The published adapters. `react` first because it is the default tab. */
+export type Framework = "react" | "vue" | "svelte" | "solid" | "preact";
+
+/**
+ * How a framework spells an attribute, which is the only axis they differ on.
+ *
+ * `jsx` covers React, Solid and Preact — three different runtimes that read the
+ * identical source, so the snippet for one is the snippet for the others with
+ * the package name swapped. Svelte's template is close enough to JSX in the
+ * attribute position to share its rules and differs only in the module wrapper;
+ * Vue differs in both.
+ */
+export type Flavor = "jsx" | "svelte" | "vue";
+
+export interface FrameworkInfo {
+  id: Framework;
+  /** The published package the snippet imports from. */
+  pkg: string;
+  /** The filename shown above the code box, which is how a reader places it. */
+  file: string;
+  flavor: Flavor;
+}
+
+export const FRAMEWORKS: readonly FrameworkInfo[] = [
+  { id: "react", pkg: "@blobatar/react", file: "Blobatar.tsx", flavor: "jsx" },
+  { id: "vue", pkg: "@blobatar/vue", file: "Blobatar.vue", flavor: "vue" },
+  { id: "svelte", pkg: "@blobatar/svelte", file: "Blobatar.svelte", flavor: "svelte" },
+  { id: "solid", pkg: "@blobatar/solid", file: "Blobatar.tsx", flavor: "jsx" },
+  { id: "preact", pkg: "@blobatar/preact", file: "Blobatar.tsx", flavor: "jsx" },
+];
+
+const BY_ID = new Map(FRAMEWORKS.map(f => [f.id, f]));
+
+export const isFramework = (v: string): v is Framework => BY_ID.has(v as Framework);
+
+/** Never `undefined`: an id off this table is a bug, and React is the honest fallback. */
+export const infoFor = (id: Framework): FrameworkInfo => BY_ID.get(id) ?? FRAMEWORKS[0]!;
+
+/**
+ * Both packages, in the order you install them.
+ *
+ * Core is not a transitive dependency of an adapter — every adapter declares it
+ * as a peer (`"blobatar": "2.x"`), so it has to be named here or the paste
+ * produces an unmet peer warning and no renderer. See the adapters'
+ * `//peerDependencies` note.
+ */
+export const installFor = (id: Framework) => `bun add blobatar ${infoFor(id).pkg}`;
+
+/**
+ * A string-valued attribute.
+ *
+ * The two template flavors part company here, and it is worth being precise
+ * about why rather than treating one as the other's dialect.
+ *
+ * JSX attribute strings are not JS strings — no backslash escapes — so a name
+ * containing a quote cannot be written as `name="…"` at all, and falls through
+ * to an expression container. Svelte's template takes the same escape hatch
+ * with the same syntax.
+ *
+ * Vue needs no escape hatch, because its template really is HTML: the quote is
+ * an entity, and `name="say &quot;hi&quot;"` is a plain static prop whose value
+ * is exactly the name. The expression form was the obvious first move here and
+ * is the wrong one — `:name="'say "hi"'"` closes the attribute on its own third
+ * quote, and no amount of JS-level escaping reaches a problem that happens one
+ * layer above JS.
+ */
+export function attrString(flavor: Flavor, name: string, value: string): string {
+  if (flavor === "vue") return `${name}="${htmlAttr(value)}"`;
+  return /["\\]/.test(value)
+    ? `${name}={${JSON.stringify(value)}}`
+    : `${name}="${value}"`;
+}
+
+/**
+ * A value going into a double-quoted HTML attribute.
+ *
+ * `&` first, or the second replace's output gets escaped by the first on a
+ * later pass — the classic ordering bug in a two-line escaper.
+ */
+const htmlAttr = (value: string) =>
+  value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+
+/** A JS expression in attribute position — a number, an identifier, an object literal. */
+export const attrExpr = (flavor: Flavor, name: string, expr: string) =>
+  flavor === "vue" ? `:${name}="${expr}"` : `${name}={${expr}}`;
+
+/**
+ * The same expression attribute, opened and closed on different lines.
+ *
+ * `attrExpr` cannot serve a multi-line object literal — it closes what it
+ * opens — and the two delimiters are not the same character on both ends in
+ * Vue, so a caller cannot simply reuse one of them reversed. Hence a pair.
+ */
+export const exprOpen = (flavor: Flavor, name: string) =>
+  flavor === "vue" ? `:${name}="{` : `${name}={{`;
+
+export const exprClose = (flavor: Flavor) => (flavor === "vue" ? `}"` : "}}");
+
+/**
+ * A JS string literal in single quotes.
+ *
+ * `JSON.stringify` is the wrong tool here and quietly so: it emits the double
+ * quotes that are the whole problem. Escaping by hand is two characters —
+ * backslash first, or it doubles the ones the second replace adds.
+ */
+const singleQuoted = (value: string) =>
+  `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+
+const bare = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * An object key, quoted only where it has to be.
+ *
+ * `shape` is a valid identifier and `"eye.gap"` is not. The quote *character*
+ * follows the flavor for the same reason `attrString` does: a Vue object
+ * literal lives inside a double-quoted attribute, so a double-quoted key inside
+ * it closes the attribute early and the template stops parsing.
+ */
+export const objectKey = (flavor: Flavor, k: string) =>
+  bare.test(k) ? k : flavor === "vue" ? singleQuoted(k) : JSON.stringify(k);
+
+/**
+ * A comment in *markup* position, which is not the same language as the script.
+ *
+ * The one thing a template flavor cannot borrow from JSX. `// …` beside a JSX
+ * element is a comment; the identical line inside a Svelte or Vue template is
+ * text, and it renders — so a snippet that took the JSX spelling everywhere
+ * would paste into a Vue app and draw its own annotation on the page next to
+ * the blobatar. Inside `<script>` the JS spelling is correct and this helper is
+ * not the one to reach for.
+ */
+export const comment = (flavor: Flavor, text: string) =>
+  flavor === "jsx" ? `// ${text}` : `<!-- ${text} -->`;
+
+/**
+ * The module around the element.
+ *
+ * JSX has none — the imports and the element are the file. The two
+ * single-file-component formats wrap it, and they disagree about indentation
+ * inside `<script>`: Svelte's convention indents the body, Vue's `<script
+ * setup>` does not. Following each rather than picking one keeps the output
+ * looking like the framework's own docs, which is the entire job of a snippet.
+ */
+export function wrap(flavor: Flavor, imports: string[], element: string[]): string {
+  if (flavor === "jsx") return [...imports, "", ...element].join("\n");
+
+  if (flavor === "svelte")
+    return [
+      "<script>",
+      ...imports.map(line => `  ${line}`),
+      "</script>",
+      "",
+      ...element,
+    ].join("\n");
+
+  return [
+    "<script setup>",
+    ...imports,
+    "</script>",
+    "",
+    "<template>",
+    ...element.map(line => `  ${line}`),
+    "</template>",
+  ].join("\n");
+}
+
+/**
+ * The element's closing line.
+ *
+ * `semi` is the caller's, not the flavor's: JSX *can* carry a statement
+ * terminator and the editor's snippet does, because it is a standalone
+ * expression you paste. A template language cannot carry one at all, so the
+ * request is honored only where it is legal.
+ */
+export const close = (flavor: Flavor, semi = false) =>
+  semi && flavor === "jsx" ? "/>;" : "/>";


### PR DESCRIPTION
The site advertised two adapters and five were published. Both snippet surfaces now cover all five, and the README documents the three that were missing.

## The site

`apps/site/src/frameworks.ts` is new: one table holding each adapter's package, filename and syntax flavor (`jsx` for React/Solid/Preact, plus `svelte` and `vue`), with the spelling helpers both generators share. A sixth adapter is a row in that table, not two new emitters.

- **Editor** — the first segment of the API strip is now a tab *and* a menu. Clicking it while another tab is active selects it; clicking it while it is already active opens the framework list. The strip keeps its three slots, which seven flat chips would not have fit in that column.
- **Hero** — a compact picker beside the filename, which now tracks the framework (`Blobatar.svelte`). The four tuning axes are untouched.
- **Install pill** — follows the tab. Core is a peer of every adapter rather than a dependency, so a `bun add blobatar` under a Svelte snippet is a paste that cannot resolve its own import.

## Three things the templates broke on

Each is now pinned by a test, because one emitter serving five flavors is exactly the shape that can be quietly wrong for four of them:

- **`//` is not a comment in a Vue or Svelte template** — it renders. Both the "everything below comes from the name" note and the hero's `// shape: cloud` would have pasted a visible annotation onto the page beside the blobatar. They emit `<!-- … -->` in markup position now.
- **Vue quoting** — `:traits="{ "eye.gap": 0.8 }"` closes the attribute on its third quote and the template stops parsing. Vue keys use single quotes; JSX and Svelte keep double.
- **A name containing a quote** — the first attempt was `:name="'say "hi"'"`, which fails one layer above JS. Vue's template is HTML, so it is `name="say &quot;hi&quot;"`; JSX and Svelte keep the expression-container escape hatch.

## README

Adds `### Svelte` (with the source-resolved caveat and a pointer to ADR-0010) and `### Solid and Preact`, and generalises the two lines that named React and Vue as the only component APIs.

## Checks

73 tests pass, typecheck is clean on the changed files, and the site build passes its CSS gate. Both pages were screenshotted at 2x — the strip, the open menu and the hero header all render as intended.

https://claude.ai/code/session_01Y7M3UDT7JqcX279PnhJpDk