### PR TITLE
docs: use nuqs to store controls in the URL

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.3.1",
+    "nuqs": "^2.10.0",
     "react": "^19",
     "react-dom": "^19",
     "tailwind-merge": "^3.0.1"

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -2,20 +2,23 @@ import { Hero } from "@/components/Hero";
 import { Wall } from "@/components/Wall";
 import { Chat } from "@/components/Chat";
 import { Close } from "@/components/Close";
+import { NuqsAdapter } from "nuqs/adapters/react";
 
 export function App() {
   return (
-    <main>
-      <Hero />
-      <Wall />
-      {/*
-        After the wall, and the order is the argument: the wall claims the
-        blobatars are all different, the chat shows what that difference is
-        *for*. Reversed, the chat is a screenshot of an app you have no reason
-        to care about yet.
-      */}
-      <Chat />
-      <Close />
-    </main>
+    <NuqsAdapter>
+      <main>
+        <Hero />
+        <Wall />
+        {/*
+          After the wall, and the order is the argument: the wall claims the
+          blobatars are all different, the chat shows what that difference is
+          *for*. Reversed, the chat is a screenshot of an app you have no reason
+          to care about yet.
+        */}
+        <Chat />
+        <Close />
+      </main>
+    </NuqsAdapter>
   );
 }

--- a/apps/site/src/components/Hero.tsx
+++ b/apps/site/src/components/Hero.tsx
@@ -1,4 +1,32 @@
-import { useEffect, useRef, useState } from "react";
+import { Caret, FrameworkMenu } from "@/components/ui/framework-menu";
+import { Install } from "@/components/ui/install";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Segmented, SegmentedItem } from "@/components/ui/segmented";
+import { Snippet } from "@/components/ui/snippet";
+import { eggFor, EggMark } from "@/eggs";
+import {
+  attrExpr,
+  attrString,
+  close,
+  comment,
+  exprClose,
+  exprOpen,
+  infoFor,
+  installFor,
+  isManager,
+  MANAGERS,
+  SHADCN_FILE,
+  wrap,
+  type Framework,
+  type Manager,
+} from "@/frameworks";
+import { cn } from "@/lib/utils";
+import { SHAPES, type ShapeOption } from "@/shapes";
 import { Blobatar } from "@blobatar/react";
 import type { BlobatarOptions } from "blobatar";
 import {
@@ -18,37 +46,18 @@ import {
   wink,
   type Expression,
 } from "blobatar/expression";
-import { Segmented, SegmentedItem } from "@/components/ui/segmented";
 import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Snippet } from "@/components/ui/snippet";
-import { SHAPES, type ShapeOption } from "@/shapes";
-import { Install } from "@/components/ui/install";
-import { Caret, FrameworkMenu } from "@/components/ui/framework-menu";
-import {
-  attrExpr,
-  attrString,
-  close,
-  comment,
-  exprClose,
-  exprOpen,
-  infoFor,
-  installFor,
-  isManager,
-  MANAGERS,
-  SHADCN_FILE,
-  type Manager,
-  wrap,
-  type Framework,
-} from "@/frameworks";
-import { EggMark, eggFor } from "@/eggs";
-import { cn } from "@/lib/utils";
+  createParser,
+  debounce,
+  parseAsNumberLiteral,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from "nuqs";
+import { useEffect, useRef, useState } from "react";
 
-type Bg = "none" | "squircle" | "circle" | "square";
+const backgrounds = ["none", "squircle", "circle", "square"] as const;
+type Bg = (typeof backgrounds)[number];
 
 /**
  * Eight stops around the wheel plus an auto chip.
@@ -58,7 +67,7 @@ type Bg = "none" | "squircle" | "circle" | "square";
  * has nowhere to express "unset", and implies a precision nobody tuning a
  * landing page wants.
  */
-const HUES = [12, 40, 78, 140, 190, 225, 275, 320];
+const HUES = [12, 40, 78, 140, 190, 225, 275, 320] as const;
 
 /**
  * One silhouette option: its name and the trait position that selects it.
@@ -92,6 +101,31 @@ const POSES = [
 ] as const;
 
 type Pose = (typeof POSES)[number];
+
+function parseAsNamedObject<T extends { name: string }>(list: readonly T[]) {
+  return createParser({
+    parse(query) {
+      const item = list.find((p) => p.name === query);
+      return item ?? null;
+    },
+    serialize(item) {
+      return item.name;
+    },
+    eq: (a, b) => a.name === b.name,
+  });
+}
+
+const controlsSearchParams = {
+  seed: parseAsString.withDefault("alain00"),
+  bg: parseAsStringLiteral(backgrounds).withDefault("none"),
+  hue: parseAsNumberLiteral(HUES),
+  pose: parseAsNamedObject(POSES).withDefault(POSES[0]),
+  shape: parseAsNamedObject(SHAPES),
+};
+
+function useControls() {
+  return useQueryStates(controlsSearchParams);
+}
 
 /**
  * How many of the roster the panel shows without being asked.
@@ -258,11 +292,7 @@ export function shadcnSnippet(
 }
 
 export function Hero() {
-  const [seed, setSeed] = useState("alain00");
-  const [bg, setBg] = useState<Bg>("none");
-  const [hue, setHue] = useState<number | null>(null);
-  const [pose, setPose] = useState<Pose>(POSES[0]);
-  const [shape, setShape] = useState<Shape | null>(null);
+  const [{ seed, bg, hue, pose, shape }, setControls] = useControls();
 
   /**
    * Which adapter the snippet is written in.
@@ -353,7 +383,7 @@ export function Hero() {
   const pick = (p: Pose) => {
     clearTimeout(release.current ?? undefined);
     setBurst(null);
-    setPose(p);
+    setControls({ pose: p });
   };
 
   const opts: BlobatarOptions = {
@@ -472,7 +502,14 @@ export function Hero() {
                   // from a previous name lands the click reaction on the reveal
                   // of the next one, and the two transforms fight.
                   onChange={(e) => {
-                    setSeed(e.target.value);
+                    setControls(
+                      { seed: e.target.value },
+                      {
+                        limitUrlUpdates: e.target.value
+                          ? debounce(250)
+                          : undefined,
+                      },
+                    );
                     setNudge(false);
                   }}
                   spellCheck={false}
@@ -617,7 +654,7 @@ export function Hero() {
                       seed={seed}
                       opts={{ ...opts, traits: undefined }}
                       selected={shape === null}
-                      onClick={() => setShape(null)}
+                      onClick={() => setControls({ shape: null })}
                     />
                     {SHAPES.map((s) => (
                       <ShapeTile
@@ -626,7 +663,7 @@ export function Hero() {
                         seed={seed}
                         opts={{ ...opts, traits: { shape: s.at } }}
                         selected={shape?.name === s.name}
-                        onClick={() => setShape(s)}
+                        onClick={() => setControls({ shape: s })}
                       />
                     ))}
                   </div>
@@ -737,7 +774,7 @@ export function Hero() {
                   <Segmented
                     type="single"
                     value={bg}
-                    onValueChange={(v) => v && setBg(v as Bg)}
+                    onValueChange={(v) => v && setControls({ bg: v as Bg })}
                     aria-label="Background"
                   >
                     {/*
@@ -767,7 +804,7 @@ export function Hero() {
                     aria-label="Hue"
                   >
                     <button
-                      onClick={() => setHue(null)}
+                      onClick={() => setControls({ hue: null })}
                       aria-pressed={hue === null}
                       className={cn(
                         "border-line rounded-full border px-2.5 py-0.5 text-[0.7rem] lowercase transition-colors",
@@ -781,7 +818,7 @@ export function Hero() {
                     {HUES.map((h) => (
                       <button
                         key={h}
-                        onClick={() => setHue(h)}
+                        onClick={() => setControls({ hue: h })}
                         aria-label={`Hue ${h} degrees`}
                         aria-pressed={hue === h}
                         style={{ background: `oklch(0.72 0.15 ${h})` }}

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "geist": "^1.3.1",
+        "nuqs": "^2.10.0",
         "react": "^19",
         "react-dom": "^19",
         "tailwind-merge": "^3.0.1",
@@ -729,6 +730,8 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.13", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ=="],
 
     "@sveltejs/load-config": ["@sveltejs/load-config@0.2.3", "", {}, "sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ=="],
@@ -1340,6 +1343,8 @@
     "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "nuqs": ["nuqs@2.10.0", "", { "dependencies": { "@standard-schema/spec": "1.1.0" }, "peerDependencies": { "@remix-run/react": ">=2", "@tanstack/react-router": "^1", "next": ">=14.2.0", "react": ">=18.2.0 || ^19.0.0-0", "react-router": "^5 || ^6 || ^7 || ^8", "react-router-dom": "^5 || ^6 || ^7" }, "optionalPeers": ["@remix-run/react", "@tanstack/react-router", "next", "react-router", "react-router-dom"] }, "sha512-uy62jWCXiU1mcGfoClUFNTfrbaxfPQ8WuiomYlkXw5llVdN8kRZVYxOQ2LD70k3DzVQz5bZczE9ClVXwOC22Dw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 


### PR DESCRIPTION
This allows sharing your avatar config, bookmarking it, navigating back to it in your browser history etc..

E.g.: https://blobatar.dev/?seed=franky47&hue=40&pose=happy&shape=triangle

There is a mention of "No shareable URL string" in the `editor-spec.md` file, but it looks like this is scoped to the library, and this change only impacts the site. In only replaces the hero controls from `useState` to `useQueryStates` which syncs against the URL.

I figured the package manager & framework for the code part is more of an ephemeral state and wouldn't need sharing.

Demo:

https://github.com/user-attachments/assets/7b5e1c44-5fb9-46e1-98e1-6dd8bc0ae7f9